### PR TITLE
fix issue #2 using ALIVE flag for graceful termination of threads

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -251,6 +251,7 @@ class ReaderThread(threading.Thread):
         # select or other thing to wait for input on our children,
         # while breaking out every once in a while to setup selects
         # on new children.
+        global ALIVE
         while ALIVE:
             for col in all_living_collectors():
                 for line in col.collect():
@@ -371,6 +372,7 @@ class SenderThread(threading.Thread):
            send it.  A little better than sending every line as its
            own packet."""
 
+        global ALIVE
         while ALIVE:
             self.maintain_conn()
             try:
@@ -408,7 +410,8 @@ class SenderThread(threading.Thread):
             return False
 
         bufsize = 4096
-        while True:
+        global ALIVE
+        while ALIVE:
             # try to read as much data as we can.  at some point this is going
             # to block, but we have set the timeout low when we made the
             # connection
@@ -471,7 +474,8 @@ class SenderThread(threading.Thread):
         # connection didn't verify, so create a new one.  we might be in
         # this method for a long time while we sort this out.
         try_delay = 1
-        while True:
+        global ALIVE
+        while ALIVE:
             if self.verify_conn():
                 return
 
@@ -834,6 +838,13 @@ def kill(proc, signum=signal.SIGTERM):
 def shutdown():
     """Called by atexit and when we receive a signal, this ensures we properly
        terminate any outstanding children."""
+
+    global ALIVE
+    # prevent repeated calls
+    if not ALIVE:
+        return
+    # notify threads of program termination
+    ALIVE = False
 
     LOG.info('shutting down children')
 


### PR DESCRIPTION
This patch should fix the tcollector failure to exit. python apparently does not allow a generic mechanism for interrupting threads hung in sleep or Queue.get or other blocking operations, so there will be a slight delay before tcollector exits (up to 5 seconds or so). The existing ALIVE flag is used to signal to the reader and sender threads that they should terminate. The sys.exit call is supposed to only throw an exception in the current (main) thread, so I do not know why in some environments (Python 2.6 on solaris for me) graceful termination works fine without this fix, while others do not (Python 2.7 on Fedora 15).

I tried setting the threads to be daemon threads. This works, and there is no delay on termination, but I got a segfault once, which indicates that python is not happy if you catch one of the two daemon threads in the wrong spot when you exit.. not cool.
