### PR TITLE
Ability to pass additional tags.

### DIFF
--- a/startstop
+++ b/startstop
@@ -13,7 +13,10 @@ HOSTNAME=$(hostname)
 PIDFILE=${PIDFILE-'/var/run/tcollector.pid'}
 PROG=$TCOLLECTOR_PATH/tcollector.py
 LOG=${LOG-'/var/log/tcollector.log'}
-ARGS="-c $TCOLLECTOR_PATH/collectors -H $TSD_HOST -t host=$HOSTNAME -P $PIDFILE"
+COMMAND=$1
+shift
+ARGS="-c $TCOLLECTOR_PATH/collectors -H $TSD_HOST -t host=$HOSTNAME \
+-P $PIDFILE $*"
 
 # Sanity checks.
 test -d "$TCOLLECTOR_PATH" || {
@@ -84,7 +87,7 @@ forcerestart () {
     start
 }
 
-case $1 in
+case $COMMAND in
     start)  status || start
         ;;
     force-restart)
@@ -113,7 +116,8 @@ case $1 in
     status) status
             exit $?
         ;;
-    *)  echo >&2 "usage: $0 <start|stop|restart|status|force-restart>"
+    *)  echo >&2 "usage: $0 \
+<start {-t foo=bar -t baz=qux}|stop|restart|status|force-restart>"
         exit 1
         ;;
 esac


### PR DESCRIPTION
It may be necessary to pass additional tags when running tcollect.
In our case we are monitoring host level OpenStack systems, and
want to roll up into availability zones and hypervisor type.

./startstop start -t az=paloalto0 hv=kvm

Let me know if this is not clear, pointless, or can be accomplished another way.

Thanks -

John
