### PR TITLE
Add RotatingFileHandler handler options to tcollector.

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 import threading
 import time
+from logging.handlers import RotatingFileHandler
 from Queue import Queue
 from Queue import Empty
 from Queue import Full
@@ -42,6 +43,8 @@ from optparse import OptionParser
 # global variables.
 COLLECTORS = {}
 GENERATION = 0
+NOT_SET = 0
+DEFAULT_LOG = '/var/log/tcollector.log'
 LOG = logging.getLogger('tcollector')
 ALIVE = True
 # If the SenderThread catches more than this many consecutive uncaught
@@ -592,10 +595,17 @@ class SenderThread(threading.Thread):
         # the packets out of the kernel's queue
 
 
-def setup_logging():
+def setup_logging(logfile=DEFAULT_LOG, max_bytes=None, backup_count=NOT_SET):
+    """Sets up logging and associated handlers."""
 
     LOG.setLevel(logging.INFO)
-    ch = logging.StreamHandler(sys.stdout)
+    if backup_count > NOT_SET:
+      # setup log rotation handler
+      ch = RotatingFileHandler(logfile, 'a', max_bytes, backup_count)
+    else:
+      # setup stream handler
+      ch = logging.StreamHandler(sys.stdout)
+
     ch.setFormatter(logging.Formatter('%(asctime)s %(name)s[%(process)d] '
                                       '%(levelname)s: %(message)s'))
     LOG.addHandler(ch)
@@ -648,6 +658,15 @@ def parse_cmdline(argv):
                       help='Number of seconds after which to remove cached '
                            'values of old data points to save memory. '
                            'default=%default')
+    parser.add_option('--max-bytes', dest='max_bytes', type='int',
+                      default=1000000,
+                      help='Maximum bytes per a logfile.')
+    parser.add_option('--backup-count', dest='backup_count', type='int',
+                      default=NOT_SET,
+                      help='Maximum number of logfiles to backup.')
+    parser.add_option('--logfile', dest='logfile', type='str',
+                      default=DEFAULT_LOG,
+                      help='Filename where logs are written to.') 
     (options, args) = parser.parse_args(args=argv[1:])
     if options.dedupinterval < 2:
       parser.error('--dedup-interval must be at least 2 seconds')
@@ -660,8 +679,8 @@ def parse_cmdline(argv):
 def main(argv):
     """The main tcollector entry point and loop."""
 
-    setup_logging()
     options, args = parse_cmdline(argv)
+    setup_logging(options.logfile, options.max_bytes, options.backup_count)
 
     if options.verbose:
         LOG.setLevel(logging.DEBUG)  # up our level


### PR DESCRIPTION
While using tcollector we noticed that the operating system (Linux) would keep open the file descriptor for the log file even after the file did not exist.  This happens because tcollector does not close its file descriptor when log rotation happens.

This commit has one goal: to ensure that a finite amount of disk space is used for logging, regardless of how the collecting are behaving (or maybe misbehaving).

The commit aims to be compatible with the existing options, but added a few more options to allow the inclusion of a RotatingFileHandler:
- max-bytes:  Maximum number of bytes per a logfile to retain (default: 1 million bytes)
- backup-count: Number of logfiles to keep on hand (default: only one log file)
- logfile: log filename (default: /var/log/tcollector.log)

If these options are not given, then it defaults to the existing behavior:  using the StreamHandler, which will still write to stdout.
