### PR TITLE
Updating procstats.py to use per-cpu breakdowns

### DIFF
--- a/collectors/0/procstats.py
+++ b/collectors/0/procstats.py
@@ -125,23 +125,22 @@ def main():
             m = re.match("(\w+)\s+(.*)", line)
             if not m:
                 continue
-            if m.group(1) == "cpu":
+            cm = re.match("(cpu\d+)", m.group(1))
+            if cm:
                 fields = m.group(2).split()
-                print "proc.stat.cpu %d %s type=user" % (ts, fields[0])
-                print "proc.stat.cpu %d %s type=nice" % (ts, fields[1])
-                print "proc.stat.cpu %d %s type=system" % (ts, fields[2])
-                print "proc.stat.cpu %d %s type=idle" % (ts, fields[3])
-                print "proc.stat.cpu %d %s type=iowait" % (ts, fields[4])
-                print "proc.stat.cpu %d %s type=irq" % (ts, fields[5])
-                print "proc.stat.cpu %d %s type=softirq" % (ts, fields[6])
+                print ("proc.stat.cpu %d %s cpu=%s type=user" % (ts, fields[0], cm.group(1)))
+                print ("proc.stat.cpu %d %s cpu=%s type=nice" % (ts, fields[1], cm.group(1)))
+                print ("proc.stat.cpu %d %s cpu=%s type=system" % (ts, fields[2], cm.group(1)))
+                print ("proc.stat.cpu %d %s cpu=%s type=idle" % (ts, fields[3], cm.group(1)))
+                print ("proc.stat.cpu %d %s cpu=%s type=iowait" % (ts, fields[4], cm.group(1)))
+                print ("proc.stat.cpu %d %s cpu=%s type=irq" % (ts, fields[5], cm.group(1)))
+                print ("proc.stat.cpu %d %s cpu=%s type=softirq" % (ts, fields[6], cm.group(1)))
                 # really old kernels don't have this field
                 if len(fields) > 7:
-                    print ("proc.stat.cpu %d %s type=guest"
-                           % (ts, fields[7]))
+                    print ("proc.stat.cpu %d %s cpu=%s type=steal" % (ts, fields[7], cm.group(1)))
                     # old kernels don't have this field
                     if len(fields) > 8:
-                        print ("proc.stat.cpu %d %s type=guest_nice"
-                               % (ts, fields[8]))
+                        print ("proc.stat.cpu %d %s cpu=%s type=guest" % (ts, fields[8], cm.group(1)))            
             elif m.group(1) == "intr":
                 print ("proc.stat.intr %d %s"
                         % (ts, m.group(2).split()[0]))


### PR DESCRIPTION
...Instead of the aggregated "cpu" line. This works even in the case of single-core boxes, which have identical cpu and cpu0 lines.

Also, I corrected the tag names for columns 8 and 9 to steal and guest as per proc(5).

Output difference:

[root@ip ~]# python procstats.py|grep cpu
proc.stat.cpu 1335387940 100432039 cpu=cpu0 type=user
proc.stat.cpu 1335387940 186466 cpu=cpu0 type=nice
proc.stat.cpu 1335387940 40000695 cpu=cpu0 type=system
proc.stat.cpu 1335387940 795129191 cpu=cpu0 type=idle
proc.stat.cpu 1335387940 186613885 cpu=cpu0 type=iowait
proc.stat.cpu 1335387940 0 cpu=cpu0 type=irq
proc.stat.cpu 1335387940 4989755 cpu=cpu0 type=softirq
proc.stat.cpu 1335387940 9350148 cpu=cpu0 type=steal
proc.stat.cpu 1335387940 34197075 cpu=cpu1 type=user
proc.stat.cpu 1335387940 205380 cpu=cpu1 type=nice
proc.stat.cpu 1335387940 27119372 cpu=cpu1 type=system
proc.stat.cpu 1335387940 1056442263 cpu=cpu1 type=idle
proc.stat.cpu 1335387940 11829759 cpu=cpu1 type=iowait
proc.stat.cpu 1335387940 0 cpu=cpu1 type=irq
proc.stat.cpu 1335387940 988071 cpu=cpu1 type=softirq
proc.stat.cpu 1335387940 5920258 cpu=cpu1 type=steal

[root@ip ~]# python /opt/tcollector/collectors/0/procstats.py |grep cpu
proc.stat.cpu 1335387959 134629939 type=user
proc.stat.cpu 1335387959 391847 type=nice
proc.stat.cpu 1335387959 67120733 type=system
proc.stat.cpu 1335387959 1851573093 type=idle
proc.stat.cpu 1335387959 198443645 type=iowait
proc.stat.cpu 1335387959 0 type=irq
proc.stat.cpu 1335387959 5978215 type=softirq
proc.stat.cpu 1335387959 15270804 type=guest
