### PR TITLE
Zombie process issue fix

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -798,7 +798,7 @@ def main_loop(options, modules, sender, tags):
     """The main loop of the program that runs when we're not in stdin mode."""
 
     next_heartbeat = int(time.time() + 600)
-    global ALIVE
+
     while ALIVE:
         populate_collectors(options.cdir)
         reload_changed_config_modules(modules, options, sender, tags)
@@ -1050,7 +1050,6 @@ def spawn_children():
        determine if we need to spawn, kill, or otherwise take some
        action on them."""
 
-    global ALIVE
     if not ALIVE:
         return
 


### PR DESCRIPTION
I ran into an issue where the tcollector SenderThread had reached its threshold of uncaught exceptions. This caused it to call shutdown. Which tore down the Reader and the Sender threads. The main thread however was still running causing tcollector to be in bad state. 

This change should fix that. 
