### PR TITLE
retry on temporary name resolution errors

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -574,8 +574,13 @@ class SenderThread(threading.Thread):
 
             # Now actually try the connection.
             self.pick_connection()
-            addresses = socket.getaddrinfo(self.host, self.port, socket.AF_UNSPEC,
-                                          socket.SOCK_STREAM, 0)
+            try:
+                addresses = socket.getaddrinfo(self.host, self.port, socket.AF_UNSPEC,
+                                              socket.SOCK_STREAM, 0)
+            except socket.gaierror, e:
+                if e[0] == socket.EAI_AGAIN:
+                    continue
+                raise
             for family, socktype, proto, canonname, sockaddr in addresses:
                 try:
                     self.tsd = socket.socket(family, socktype, proto)


### PR DESCRIPTION
I noticed this when debugging the issue fixed by f2bf2bc, temporary gaierrors should be retried IMO. Also typo fix while I was at it.

thanks!
