### PR TITLE
Remove unnecessary replacement of forward slash "/" to "_".

### DIFF
--- a/collectors/0/dfstat.py
+++ b/collectors/0/dfstat.py
@@ -26,11 +26,6 @@
 # This makes it easier to exclude stuff like
 # tmpfs mounts from disk usage reports.
 
-# Because tsdb does not like slashes in tags, slashes will
-# be replaced by underscores in the mount= tag.  In theory
-# this could cause problems if you have a mountpoint of
-# "/foo/bar/" and "/foo_bar/".
-
 
 import subprocess
 import sys

--- a/collectors/0/iostat.py
+++ b/collectors/0/iostat.py
@@ -121,9 +121,7 @@ def main():
             else:
                 metric = "iostat.part."
 
-            # Sometimes there can be a slash in the device name, see bug #8.
-            # TODO(tsuna): Remove the substitution once TSD allows `/' in tags.
-            device = values[2].replace("/", "_")
+            device = values[2]
             if len(values) == 14:
                 # full stats line
                 for i in range(11):


### PR DESCRIPTION
I suppose tag names are allowed to have forward slash "/" now as Tags.validateString permits them.

I can't find actual replacement in dfstat.py, so I just deleted comment about replacement.
