### PR TITLE
Hbase collector for 0.94

### DIFF
--- a/collectors/0/hbase_regionserver_jmx.py
+++ b/collectors/0/hbase_regionserver_jmx.py
@@ -31,7 +31,7 @@ JAVA = "%s/bin/java" % JAVA_HOME
 
 # We add those files to the classpath if they exist.
 CLASSPATH = [
-    "%s/lib/tools.jar" % JAVA_HOME
+    "%s/lib/tools.jar" % JAVA_HOME,
 ]
 
 # We shorten certain strings to avoid excessively long metric names.
@@ -48,7 +48,7 @@ REPORTED_OPS = [
   "get",
   "put",
   "multi",
-  "balance"
+  "balance",
 ]
 
 


### PR DESCRIPTION
Made following changes:
1. Use JAVA_HOME env variable to locate java executable and tools.jar. Some people use Oracle's JDK. If not set it still defaults to OpenJDK 1.6.0 
2. Change JVM to attach to from HMaster to HRegionServer
3. Added bean regexp "Memory$" to collect global heap stats. This requires updated jmx.jar to work. 
4. Ignore metrics with "BlockedSeconds" and "LatencyHistogram" in them - too much spam and little value IMHO
5. Ignore metrics from RegionServerDynamicStatistics, this includes per table and per CF metrics
6. For the *_NumOps|AvgTime|MaxTime metrics, only report for operations in REPORTED_OPS list. Otherwise the list of operations is huge. 
7. For the metrics that end in _KB or _MB, convert value to bytes and remove suffix from the metric. 

This now works fine for our Hbase 0.94.9 cluster. I have no means to test it for other HBase versions though. 

Limus
