### PR TITLE
Redis: add per database metrics

### DIFF
--- a/collectors/0/redis-stats.py
+++ b/collectors/0/redis-stats.py
@@ -137,7 +137,7 @@ def main():
             # per database metrics
             for db in filter(dbre.match, info.keys()):
                 for db_metric in info[db].keys():
-                    print_stat(db + '.' + db_metric, info[db][db_metric], tags)
+                    print_stat(db_metric, info[db][db_metric], "%s db=%s" % (tags, db))
 
             # get some instant latency information
             # TODO: might be nice to get 95th, 99th, etc here?


### PR DESCRIPTION
The redis [info](http://redis.io/commands/info) command reports metrics for the total number of keys and the number of those with a ttl, for each database hosted by the redis process. This change reports those numbers. Useful for spotting data leaks.
