### PR TITLE
Update elasticsearch.py

### DIFF
--- a/collectors/0/elasticsearch.py
+++ b/collectors/0/elasticsearch.py
@@ -133,7 +133,7 @@ def main(argv):
 
     if "os" in nstats:
        ts = nstats["os"]["timestamp"] / 1000  # ms -> s
-    if "timestamp" in nststs:
+    if "timestamp" in nstats:
        ts = nstats["timestamp"] / 1000  # ms -> s
 
     if "indices" in nstats:


### PR DESCRIPTION
Correct misspelled variable name.

Throws:

2013-11-08 14:29:12,731 tcollector[27472] WARNING: elasticsearch.py: Traceback (most recent call last):
2013-11-08 14:29:12,731 tcollector[27472] WARNING: elasticsearch.py:   File "/usr/lib/tcollector/collectors/0/elasticsearch.py", line 247, in <module>
2013-11-08 14:29:12,731 tcollector[27472] WARNING: elasticsearch.py:     sys.exit(main(sys.argv))
2013-11-08 14:29:12,731 tcollector[27472] WARNING: elasticsearch.py:   File "/usr/lib/tcollector/collectors/0/elasticsearch.py", line 136, in main
2013-11-08 14:29:12,732 tcollector[27472] WARNING: elasticsearch.py:     if "timestamp" in nststs:
2013-11-08 14:29:12,732 tcollector[27472] WARNING: elasticsearch.py: NameError: global name 'nststs' is not defined
