### PR TITLE
Update procstats.py to send proc.meminfo.* in bytes rather than KB

### DIFF
--- a/collectors/0/procstats.py
+++ b/collectors/0/procstats.py
@@ -105,10 +105,15 @@ def main():
         f_meminfo.seek(0)
         ts = int(time.time())
         for line in f_meminfo:
-            m = re.match("(\w+):\s+(\d+)", line)
+            m = re.match("(\w+):\s+(\d+)\s+(\w+)", line)
             if m:
+                if m.group(3).lower() == 'kb':
+                    # convert from kB to B for easier graphing
+                    value = str(int(m.group(2)) * 1000)
+                else:
+                    value = m.group(2)
                 print ("proc.meminfo.%s %d %s"
-                        % (m.group(1).lower(), ts, m.group(2)))
+                        % (m.group(1).lower(), ts, value))
 
         # proc.vmstat
         f_vmstat.seek(0)


### PR DESCRIPTION
procstats reads in /proc/meminfo but the units specified are in kB.
This change checks for kB as a unit and multiplies by 1000.

```
root@server:~# cat /proc/meminfo 
MemTotal:        8200352 kB
MemFree:         4417708 kB
```

This makes it nicer to graph with a format string of `%.1s%cB` 
Currently OpenTSDB is incorrectly showing MB instead of GB

PS
Appears to always be kB in Linux
http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/filesystems/proc.txt
