### PR TITLE
Contributing kafka_jmx.py script to collect kafka MBean metrics exposed  to JMX port

### DIFF
--- a/collectors/0/kafka_jmx.py
+++ b/collectors/0/kafka_jmx.py
@@ -93,7 +93,7 @@ def main(argv):
          # The remaining arguments are pairs (mbean_regexp, attr_regexp).
          # The first regexp is used to match one or more MBeans, the 2nd
          # to match one or more attributes of the MBeans matched.
-         "kafka", "",                     # All HBase / hadoop metrics.
+         "kafka", "",                     # All kafka metrics.
          "Threading", "Count|Time$",       # Number of threads and CPU time.
          "OperatingSystem", "OpenFile",    # Number of open files.
          "GarbageCollector", "Collection", # GC runs and time spent GCing.


### PR DESCRIPTION
This script will be helpful to collect Kafka metrics for following MBean domains,
"kafka.server", 
"kafka.cluster", 
"kafka.controller",
"kafka.network", 
"kafka.log", 
"kafka.consumer", 
"java.lang"
