### PR TITLE
Add a check to exit gracefully if no block devices are found.

### DIFF
--- a/collectors/0/smart-stats.py
+++ b/collectors/0/smart-stats.py
@@ -192,6 +192,10 @@ def main():
 
   # Get the list of block devices.
   drives = [dev[5:] for dev in glob.glob("/dev/[hs]d[a-z]")]
+  # Exit gracefully if no block devices found
+  if not drives:
+    sys.exit(13)
+
 
   # to make sure we are done with smartctl in COMMAND_TIMEOUT seconds
   signal.signal(signal.SIGALRM, alarm_handler)


### PR DESCRIPTION
Some systems (VServer based VMs for example) don't supply any block devices to the guest, so exit gracefully if no block devices could be found.
