### PR TITLE
Improved HAProxy collector

### DIFF
--- a/collectors/0/haproxy.py
+++ b/collectors/0/haproxy.py
@@ -41,7 +41,7 @@ COLLECTION_INTERVAL = 15
 # for information:
 # http://haproxy.1wt.eu/download/1.4/doc/configuration.txt
 METRICS_TO_REPORT = {
-    "FRONTEND": [],
+    "FRONTEND": ["scur", "rate"],
     "BACKEND": ["scur", "rate"],
     "servers": ["scur", "rate"]
 }
@@ -77,7 +77,7 @@ METRIC_NAMES = {
     "throttle": "warm_up_status",
     "lbtot": "load_balancer_selection_count",
     "tracked": "id_of_tracked_server",
-    "rate": "sessions_per_second",
+    "rate": "session_rate",
     "rate_lim": "limit_on_new_sessions_per_second",
     "rate_max": "max_number_of_new_sessions_per_second",
     "check_code": "health_check_code",

--- a/collectors/0/haproxy.py
+++ b/collectors/0/haproxy.py
@@ -159,6 +159,9 @@ def collect_stats(sock):
           print ("haproxy.%s %i %s server=%s cluster=%s"
                  % (METRIC_NAMES[key], ts, value, line["svname"], line["pxname"]))
 
+  # make sure that we get our output
+  sys.stdout.flush()
+
 
 def main():
   pid = haproxy_pid()

--- a/collectors/0/haproxy.py
+++ b/collectors/0/haproxy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2013 The tcollector Authors.
+# Additions Copyright (C) 2014 Elastisys AB.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published by
@@ -31,9 +32,62 @@ import sys
 import time
 import stat
 import subprocess
+import csv
 from collectors.lib import utils
 
 COLLECTION_INTERVAL = 15
+
+# Which statistics to report. See Section 9.1 of the the following URL
+# for information:
+# http://haproxy.1wt.eu/download/1.4/doc/configuration.txt
+METRICS_TO_REPORT = ["scur", "rate"]
+
+METRIC_NAMES = {
+    "pxname": "proxy_name",
+    "qcur": "current_queued_requests",
+    "qmax": "max_queued_requests",
+    "scur": "current_sessions",
+    "smax": "max_sessions",
+    "slim": "sessions_limit",
+    "stot": "total_sessions",
+    "bin": "bytes_in",
+    "bout": "bytes_out",
+    "dreq": "denied_requests",
+    "dresp": "denied_responses",
+    "ereq": "request_errors",
+    "econ": "connection_errors",
+    "eresp": "response_errors",
+    "wretr": "retries_warning",
+    "wredis": "redispatches_warning",
+    "weight": "server_weight",
+    "chkfail": "number_of_failed_checks",
+    "chkdown": "number_of_UP_to_DOWN_transitions",
+    "lastchg": "last_status_change_in_seconds",
+    "downtime": "total_downtime_in_seconds",
+    "qlimit": "queue_limit",
+    "pid": "process_id",
+    "iid": "unique_proxy_id",
+    "sid": "service_id",
+    "throttle": "warm_up_status",
+    "lbtot": "load_balancer_selection_count",
+    "tracked": "id_of_tracked_server",
+    "rate": "sessions_per_second",
+    "rate_lim": "limit_on_new_sessions_per_second",
+    "rate_max": "max_number_of_new_sessions_per_second",
+    "check_code": "health_check_code",
+    "check_duration": "health_check_duration_in_milliseconds",
+    "hrsp_1xx": "http_responses_with_1xx_code",
+    "hrsp_2xx": "http_responses_with_2xx_code",
+    "hrsp_3xx": "http_responses_with_3xx_code",
+    "hrsp_4xx": "http_responses_with_4xx_code",
+    "hrsp_5xx": "http_responses_with_5xx_code",
+    "hrsp_other": "http_responses_with_other_codes",
+    "req_rate": "http_request_rate",
+    "req_rate_max": "max_observed_http_requests",
+    "req_tot": "http_requests_received",
+    "cli_abrt": "client_aborted_data_transfers",
+    "srv_abrt": "server_aborted_data_transfers"
+}
 
 def haproxy_pid():
   """Finds out the pid of haproxy process"""
@@ -68,24 +122,43 @@ def find_sock_file(conf_file):
   finally:
     fd.close()
 
+
 def collect_stats(sock):
   """Collects stats from haproxy unix domain socket"""
   sock.send("show stat\n")
-  stats = sock.recv(10240)
+  statlines = sock.recv(10240).split('\n')
+  ts = time.time()  
 
-  ts = time.time()
-  for line in stats.split("\n"):
-    var = line.split(",")
-    if var[0]:
-      # skip ready for next command value "> "
-      if var[0] == "> ":
-        continue
-      if var[1] in ("svname", "BACKEND", "FRONTEND"):
-        continue
-      print ("haproxy.current_sessions %i %s server=%s cluster=%s"
-             % (ts, var[4], var[1], var[0]))
-      print ("haproxy.session_rate %i %s server=%s cluster=%s"
-             % (ts, var[33], var[1], var[0]))
+  # eat up any empty lines that may be present
+  statlines = [line for line in statlines if line != ""]
+
+  # headers are given first, with or without the prompt present
+  headers = None
+  if statlines[0].startswith("> # "):
+    headers = statlines[0][4:].split(',')
+  elif statlines[0].startswith("# "):
+    headers = statlines[0][2:].split(',')
+  else:
+    utils.err("No headers found in HAProxy output: %s" % (statlines[0],))
+    return
+
+  reader = csv.DictReader(statlines[1:], fieldnames=headers)
+
+  # each line is a dict, due to the use of DictReader
+  for line in reader:
+      if "svname" not in line:
+          continue  # skip output from non-expected lines
+      if line["svname"] in ["FRONTEND", "BACKEND"]:
+          continue  # skip output not related to specific server
+      for key in METRICS_TO_REPORT:
+          if not line["svname"]:
+            continue  # no associated server, junk output
+          value = line[key]
+          if not value:
+              value = 0
+          print ("haproxy.%s %i %s server=%s cluster=%s"
+                 % (METRIC_NAMES[key], ts, value, line["svname"], line["pxname"]))
+
 
 def main():
   pid = haproxy_pid()

--- a/collectors/0/haproxy.py
+++ b/collectors/0/haproxy.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2013 The tcollector Authors.
-# Additions Copyright (C) 2014 Elastisys AB.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published by

--- a/collectors/0/haproxy.py
+++ b/collectors/0/haproxy.py
@@ -37,9 +37,9 @@ COLLECTION_INTERVAL = 15
 # for information:
 # http://haproxy.1wt.eu/download/1.4/doc/configuration.txt
 METRICS_TO_REPORT = {
-    "FRONTEND": ["scur", "rate"],
-    "BACKEND": ["scur", "rate"],
-    "servers": ["scur", "rate"]
+    "FRONTEND": ["scur", "rate", "req_tot", "req_rate"],
+    "BACKEND": ["scur", "rate", "req_tot", "req_rate"],
+    "servers": ["scur", "rate", "req_tot", "req_rate"]
 }
 
 METRIC_NAMES = {

--- a/collectors/0/haproxy.py
+++ b/collectors/0/haproxy.py
@@ -37,9 +37,9 @@ COLLECTION_INTERVAL = 15
 # for information:
 # http://haproxy.1wt.eu/download/1.4/doc/configuration.txt
 METRICS_TO_REPORT = {
-    "FRONTEND": ["scur", "rate", "req_tot", "req_rate"],
-    "BACKEND": ["scur", "rate", "req_tot", "req_rate"],
-    "servers": ["scur", "rate", "req_tot", "req_rate"]
+    "FRONTEND": ["scur", "stot", "rate", "req_tot", "req_rate"],
+    "BACKEND": ["scur", "stot", "rate", "req_tot", "req_rate"],
+    "servers": ["scur", "stot", "rate", "req_tot", "req_rate"]
 }
 
 METRIC_NAMES = {


### PR DESCRIPTION
# More robust HAProxy collector with simpler config

The HAProxy collector is made more robust in the face of possible HAProxy output changes by using a proper CSV parsing library, rather than relying on indices in a list. This also makes it easier to configure, since any additional values one may wish to report to the TSD simply need to be added to a list defined at the top of the file. E.g., to add the number of requests that resulted in HTTP 5xx (server errors), one simply adds `"hrsp_5xx"` to the `METRICS_TO_REPORT` list.