### PR TITLE
Revert default loglevel to INFO (changed to DEBUG in 8bb22d63)

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -686,7 +686,7 @@ class SenderThread(threading.Thread):
 def setup_logging(logfile=DEFAULT_LOG, max_bytes=None, backup_count=None):
     """Sets up logging and associated handlers."""
 
-    LOG.setLevel(logging.DEBUG)
+    LOG.setLevel(logging.INFO)
     if backup_count is not None and max_bytes is not None:
         assert backup_count > 0
         assert max_bytes > 0


### PR DESCRIPTION
8bb22d63 switched the default log level to DEBUG making for some really noisy logs - i don't think it was deliberate?
`-v` can be used to enable debug logging, can we revert to a default of INFO?
