### PR TITLE
Ignore the nfs filesystem type.

### DIFF
--- a/collectors/0/dfstat.py
+++ b/collectors/0/dfstat.py
@@ -42,6 +42,7 @@ FSTYPE_IGNORE = frozenset([
   "cgroup",
   "debugfs",
   "devtmpfs",
+  "nfs",
   "rpc_pipefs",
   "rootfs",
 ])


### PR DESCRIPTION
Since these are networked filesystems, we generally want them collected just once at the source, rather than also at every place they get mounted.
