### PR TITLE
Flush stdout after every UDP packet received

### DIFF
--- a/collectors/0/udp_bridge.py
+++ b/collectors/0/udp_bridge.py
@@ -46,6 +46,7 @@ def main():
                 sys.stderr.write("invalid data\n")
                 break
             print data
+            sys.stdout.flush()
     except KeyboardInterrupt:
         sys.stderr.write("keyboard interrupt, exiting\n")
     finally:


### PR DESCRIPTION
Otherwise we'll sit waiting for the OS's 4k stdout buffer to fill.

Multiple datapoints could be sent in a single packet (up to `SIZE=8192`) if frantic flush()ing is a problem, though in some cursory tests it seems to perform the same as the buffered version.
