### PR TITLE
Adding connection rebind option to tcollector.

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -404,7 +404,7 @@ class SenderThread(threading.Thread):
        buffering we might need to do if we can't establish a connection
        and we need to spool to disk.  That isn't implemented yet."""
 
-    def __init__(self, reader, dryrun, hosts, self_report_stats, tags, rebindinterval):
+    def __init__(self, reader, dryrun, hosts, self_report_stats, tags, reconnectinterval):
         """Constructor.
 
         Args:
@@ -431,8 +431,8 @@ class SenderThread(threading.Thread):
         self.port = None  # The port of the current TSD.
         self.tsd = None   # The socket connected to the aforementioned TSD.
         self.last_verify = 0
-        self.rebindinterval = rebindinterval    # rebindinterval in seconds.
-        self.time_reconnect = 0                 # if rebindinterval > 0, used to track the time.
+        self.reconnectinterval = reconnectinterval    # reconnectinterval in seconds.
+        self.time_reconnect = 0                 # if reconnectinterval > 0, used to track the time.
         self.sendq = []
         self.self_report_stats = self_report_stats
 
@@ -520,8 +520,8 @@ class SenderThread(threading.Thread):
         if self.last_verify > time.time() - 60:
             return True
 
-        # in case rebind is activated, check if it's time to rebind
-        if self.rebindinterval > 0 and self.time_reconnect < time.time() - self.rebindinterval:
+        # in case reconnect is activated, check if it's time to reconnect
+        if self.reconnectinterval > 0 and self.time_reconnect < time.time() - self.reconnectinterval:
             # closing the connection and indicating that we need to reconnect.
             try:
                 self.tsd.close()
@@ -772,10 +772,10 @@ def parse_cmdline(argv):
     parser.add_option('--logfile', dest='logfile', type='str',
                       default=DEFAULT_LOG,
                       help='Filename where logs are written to.')
-    parser.add_option('--rebind-interval',dest='rebindinterval', type='int',
-                      default=0, metavar='REBINDINTERVAL',
+    parser.add_option('--reconnect-interval',dest='reconnectinterval', type='int',
+                      default=0, metavar='RECONNECTINTERVAL',
                       help='Number of seconds after which the connection to'
-                           'the TSD hostname rebinds itself. This is useful'
+                           'the TSD hostname reconnects itself. This is useful'
                            'when the hostname is a multiple A record (RRDNS).'
                            )
     (options, args) = parser.parse_args(args=argv[1:])
@@ -784,8 +784,8 @@ def parse_cmdline(argv):
     if options.evictinterval <= options.dedupinterval:
         parser.error('--evict-interval must be strictly greater than '
                      '--dedup-interval')
-    if options.rebindinterval < 0:
-        parser.error('--rebind-interval must be at least 0 seconds')
+    if options.reconnectinterval < 0:
+        parser.error('--reconnect-interval must be at least 0 seconds')
     # We cannot write to stdout when we're a daemon.
     if (options.daemonize or options.max_bytes) and not options.backup_count:
         options.backup_count = 1
@@ -897,7 +897,7 @@ def main(argv):
 
     # and setup the sender to start writing out to the tsd
     sender = SenderThread(reader, options.dryrun, options.hosts,
-                          not options.no_tcollector_stats, tags, options.rebindinterval)
+                          not options.no_tcollector_stats, tags, options.reconnectinterval)
     sender.start()
     LOG.info('SenderThread startup complete')
 


### PR DESCRIPTION
Adding --rebind-interval option (in seconds) that will rebind the TCP connection to the TSD server.
It's leveraging the verify_conn() function to trigger a TCP reconnection.
This is particularly useful if using a round-robin DNS or any kind of VIP.

Defaults to 0 (no rebind)
