### PR TITLE
change umask back to 022 after dup2 and close calls

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -788,6 +788,7 @@ def daemonize():
     os.dup2(stdout.fileno(), 2)
     stdin.close()
     stdout.close()
+    os.umask(022)
     for fd in xrange(3, 1024):
         try:
             os.close(fd)


### PR DESCRIPTION
This prevents root-owned mode 666 .pyc files being created

Before:
bash# find -perm -666 -ls
1459179    4 -rw-rw-rw-   1 root     root          370 Jun 16 17:21 ./collectors/etc/fifo_bridge_conf.pyc
1459100    4 -rw-rw-rw-   1 root     root          128 Jun 16 17:21 ./collectors/etc/**init**.pyc
1459101    4 -rw-rw-rw-   1 root     root          243 Jun 16 17:21 ./collectors/etc/udp_bridge_conf.pyc
1589182    4 -rw-rw-rw-   1 root     root         1537 Jun 16 17:21 ./collectors/lib/utils.pyc
1589181    4 -rw-rw-rw-   1 root     root          128 Jun 16 17:21 ./collectors/lib/**init**.pyc
1459180    4 -rw-rw-rw-   1 root     root          124 Jun 16 17:21 ./collectors/**init**.pyc

After:
bash# find  -name *.pyc -ls
1523566    4 -rw-r--r--   1 root     root          370 Jun 24 11:56 ./collectors/etc/fifo_bridge_conf.pyc
1523564    4 -rw-r--r--   1 root     root          128 Jun 24 11:56 ./collectors/etc/**init**.pyc
1523565    4 -rw-r--r--   1 root     root          243 Jun 24 11:56 ./collectors/etc/udp_bridge_conf.pyc
1556588    4 -rw-r--r--   1 root     root         1537 Jun 24 11:56 ./collectors/lib/utils.pyc
1556069    4 -rw-r--r--   1 root     root          128 Jun 24 11:56 ./collectors/lib/**init**.pyc
1523567    4 -rw-r--r--   1 root     root          124 Jun 24 11:56 ./collectors/**init**.pyc

This also affects the mode of the pid file and log file.
