### PR TITLE
NUMA stat files have to be opened/closed each time to get fresh stats

### DIFF
--- a/collectors/0/procstats.py
+++ b/collectors/0/procstats.py
@@ -26,8 +26,8 @@ COLLECTION_INTERVAL = 15  # seconds
 NUMADIR = "/sys/devices/system/node"
 
 
-def open_sysfs_numa_stats():
-    """Returns a possibly empty list of opened files."""
+def find_sysfs_numa_stats():
+    """Returns a possibly empty list of NUMA stat file names."""
     try:
         nodes = os.listdir(NUMADIR)
     except OSError, (errno, msg):
@@ -39,7 +39,7 @@ def open_sysfs_numa_stats():
     numastats = []
     for node in nodes:
         try:
-            numastats.append(open(os.path.join(NUMADIR, node, "numastat")))
+            numastats.append(os.path.join(NUMADIR, node, "numastat"))
         except OSError, (errno, msg):
             if errno == 2:  # No such file or directory
                 continue
@@ -48,9 +48,9 @@ def open_sysfs_numa_stats():
 
 
 def print_numa_stats(numafiles):
-    """From a list of opened files, extracts and prints NUMA stats."""
-    for numafile in numafiles:
-        numafile.seek(0)
+    """From a list of files names, opens file, extracts and prints NUMA stats."""
+    for numafilename in numafiles:
+        numafile = open(numafilename)
         node_id = int(numafile.name[numafile.name.find("/node/node")+10:-9])
         ts = int(time.time())
         stats = dict(line.split() for line in numafile.read().splitlines())
@@ -77,6 +77,7 @@ def print_numa_stats(numafiles):
         # Pages successfully allocated with the interleave policy.
         print ("sys.numa.interleave %d %s node=%d type=hit"
                % (ts, stats["interleave_hit"], node_id))
+        numafile.close()
 
 
 def main():
@@ -104,7 +105,7 @@ def main():
         f_scaling_max[cpu_no] = open(f_scaling % (cpu_no,"max"), "r")
         f_scaling_cur[cpu_no] = open(f_scaling % (cpu_no,"cur"), "r")
 
-    numastats = open_sysfs_numa_stats()
+    numastats = find_sysfs_numa_stats()
     utils.drop_privileges()
 
     while True:


### PR DESCRIPTION
Originally in this collector, each NUMA stat file is opened and file descriptor saved in the list (function _open_sysfs_numa_stats_) and files are never closed. For each collection interval, in _print_numa_stats_, collector would do _numafile.seek(0)_ and re-read stats. However, at least on our CentOS 5.10 system, this would just print the same numbers over and over for the lifetime of the collector, even while from a different shell we could verify numbers rapidly increasing in NUMA stat files. 
The change is to rename _open_sysfs_numa_stats_ to _find_sysfs_numa_stats_ and instead of returning a list of file descriptors return list of file names. Then each file is opened, scanned and closed in each invocation of _print_numa_stats_. 
NUMA stat files seem to be world readable (verified on CentOS 5.10 and 6.5) so I don't see the reason to open files first before _drop_privileges_ is called. 
