### PR TITLE
Tweaks and unification of init wrappers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,43 @@
+tcollector (1.0-6) stable; urgency=low
+
+  * Small tweaks and unification of init wrappers.
+    Added parameter for --reconnect-interval.
+    Clean out .pyc's on startup.
+    Add some startup runlevels to the .rpm wrapper.
+    Don't strip hostnames, leave as FQDN.
+
+ -- Kieren Hynd <kieren.hynd@ticketmaster.co.uk>  Tue, 26 Aug 2014 16:13:09 +0100
+
+tcollector (1.0-5) stable; urgency=low
+
+  * Fix of invalid use of status_of_proc().
+
+ -- Vasiliy Kiryanov <vasiliy.kiryanov@gmail.com>  Fri, 27 Jun 2014 17:28:31 +0300
+
+tcollector (1.0-4) stable; urgency=low
+
+  * Expose the max-bytes and backup-count options in init script.
+
+ -- Mike Bryant <mike@mikebryant.me.uk>  Wed, 15 Jan 2014 19:02:08 +0000
+
+tcollector (1.0-3) stable; urgency=low
+
+  * Allow adding tags from the init default file.
+
+ -- Tristan Colgate <tristan@we7.com>  Fri, 18 Oct 2013 16:02:29 +0100
+
+tcollector (1.0-2) stable; urgency=low
+
+  * Fix fail of adduser/addgroup commands if the user already exists.
+
+ -- Mike Bryant <mike@mikebryant.me.uk>  Wed, 16 Oct 2013 14:20:45 +0100
+
+tcollector (1.0-1) stable; urgency=low
+
+  * Change Debian architecture from `any' to `all'.
+
+ -- Mike Bryant <mike@mikebryant.me.uk>  Sun, 13 Oct 2013 18:21:34 +0100
+
 tcollector (1.0) stable; urgency=low
 
   * Initial release.

--- a/debian/tcollector.default
+++ b/debian/tcollector.default
@@ -28,3 +28,7 @@
 # Logfile rotation settings
 #LOGFILE_MAX_BYTES=67108864
 #LOGFILE_BACKUP_COUNT=0
+
+# Disconnect and reconnect to TSD after roughly X seconds (primarily for RRDNS
+# load balancing).  Defaults to 0 (stay connected)
+#RECONNECT_INTERVAL=0

--- a/debian/tcollector.init
+++ b/debian/tcollector.init
@@ -28,6 +28,7 @@ RUN_AS_USER=${RUN_AS_USER-tcollector}
 RUN_AS_GROUP=${RUN_AS_GROUP-tcollector}
 LOGFILE_MAX_BYTES=${LOGFILE_MAX_BYTES-67108864}
 LOGFILE_BACKUP_COUNT=${LOGFILE_BACKUP_COUNT-0}
+RECONNECT_INTERVAL=${RECONNECT_INTERVAL-0}
 
 EXTRA_TAGS_OPTS=""
 for TV in $EXTRA_TAGS; do
@@ -51,6 +52,7 @@ case $1 in
         fi
         fix_perms $LOGFILE
         fix_perms $PIDFILE
+        find "$COLLECTOR_PATH" -name '*.pyc' -delete
 
         taskset=""
         if [ -n "$CPU_LIST" ]; then
@@ -65,9 +67,10 @@ case $1 in
         $taskset start-stop-daemon --start --quiet -u $RUN_AS_USER\
             --pidfile "$PIDFILE" --chuid $RUN_AS_USER:$RUN_AS_GROUP\
             --startas $DAEMON -- -c "$COLLECTOR_PATH" -L $TSD_HOSTS\
-            -t host=$HOSTNAME --dedup-interval=$DEDUP_INTERVAL\
+            -t host=$HOSTNAME --dedup-interval $DEDUP_INTERVAL\
+            --reconnect-interval $RECONNECT_INTERVAL\
             --max-bytes $LOGFILE_MAX_BYTES --backup-count $LOGFILE_BACKUP_COUNT\
-            --evict-interval=$EVICT_INTERVAL -P "$PIDFILE" -D $EXTRA_TAGS_OPTS
+            --evict-interval $EVICT_INTERVAL -P "$PIDFILE" -D $EXTRA_TAGS_OPTS
 
         log_end_msg $?
         ;;
@@ -88,7 +91,7 @@ case $1 in
         ;;
 
     status)
-        status_of_proc -p $PIDFILE "$DAEMON" "NTP server"
+        status_of_proc -p $PIDFILE "$DAEMON" "tcollector"
         exit $?
         ;;
 

--- a/rpm/ChangeLog
+++ b/rpm/ChangeLog
@@ -1,3 +1,6 @@
+* Tue Aug 26 2014 Kieren Hynd <kieren.hynd@ticketmaster.co.uk> 1.0.3-1
+- Parameter for reconnect-interval, clean .pyc's on startup, stop stripping hostnames, add some start runlevels
+
 * Mon Jun 30 2014 Stuart Warren <stuartwarren@ntlworld.com> 1.0.2-1
 - Allow setting of extra tags, lists of tsd hosts, and other logfile options.
 

--- a/rpm/initd.sh
+++ b/rpm/initd.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# tcollector        Startup script for the tcollector monitoring agent
+# tcollector   Startup script for the tcollector monitoring agent
 #
-# chkconfig: - 15 85
-# description: tcollector is an agent that collects and reports  \
+# chkconfig:   2345 15 85
+# description: tcollector is an agent that collects and reports \
 #              monitoring data for OpenTSDB.
 # processname: tcollector
 # pidfile: /var/run/tcollector.pid
@@ -22,12 +22,12 @@
 
 TSD_HOST=tsd
 THIS_HOST=`hostname`
-THIS_HOST=${THIS_HOST%%.*}
 TCOLLECTOR=${TCOLLECTOR-/usr/local/tcollector/tcollector.py}
 PIDFILE=${PIDFILE-/var/run/tcollector.pid}
 LOGFILE=${LOGFILE-/var/log/tcollector.log}
 LOGFILE_MAX_BYTES=${LOGFILE_MAX_BYTES-67108864}
 LOGFILE_BACKUP_COUNT=${LOGFILE_BACKUP_COUNT-0}
+RECONNECT_INTERVAL=${RECONNECT_INTERVAL-0}
 
 prog=tcollector
 if [ -f /etc/sysconfig/$prog ]; then
@@ -49,8 +49,9 @@ if [ -z "$OPTIONS" ]; then
     OPTIONS="$OPTIONS -H $TSD_HOST"
   fi
   OPTIONS="$OPTIONS -t host=$THIS_HOST -P $PIDFILE"
+  OPTIONS="$OPTIONS --reconnect-interval $RECONNECT_INTERVAL"
   OPTIONS="$OPTIONS --max-bytes $LOGFILE_MAX_BYTES --backup-count $LOGFILE_BACKUP_COUNT"
-  OPTIONS="$OPTIONS --logfile=$LOGFILE $EXTRA_TAGS_OPTS"
+  OPTIONS="$OPTIONS --logfile $LOGFILE $EXTRA_TAGS_OPTS"
 fi
 
 sanity_check() {
@@ -81,6 +82,7 @@ start() {
 stop() {
   echo -n $"Stopping $prog: "
   sanity_check || return $?
+  find `dirname ${TCOLLECTOR}` -name '*.pyc' -delete
   killproc -p $PIDFILE -d 15 $TCOLLECTOR
   RETVAL=$?
   echo


### PR DESCRIPTION
Added parameter for the new `--reconnect-interval`.

Clean out .pyc's on startup in both .rpm and .deb wrappers.  If a package deploys .py's for lib/ or etc/ with older timestamps than the last tcollector startup the .pyc's get used instead, which is confusing.

Don't strip hostnames (the Debian init script doesn't) and add some startup runlevels to the .rpm wrapper.
