### PR TITLE
Make per-line flushing configurable in udp_bridge

### DIFF
--- a/collectors/etc/udp_bridge_conf.py
+++ b/collectors/etc/udp_bridge_conf.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
 
 def enabled():
-  return False
+  return True
+
+def flush_delay():
+  return 60


### PR DESCRIPTION
See #155.
(also, since d3f8c792751578ecde0ff92b97acf75b093ae9b4, the UDP bridge seems to get killed off after 10 minutes, but may still hold unflushed data - on low traffic udp_bridges, flushing every line isn't an issue).

To enable, create a `flush()` function in the udp_bridge_conf that returns True.
