### PR TITLE
change cpuinfo_cur_freq to scaling_cur_freq because of access problems on wheezy

### DIFF
--- a/collectors/0/procstats.py
+++ b/collectors/0/procstats.py
@@ -91,19 +91,19 @@ def main():
     f_entropy_avail = open("/proc/sys/kernel/random/entropy_avail", "r")
     f_interrupts = open("/proc/interrupts", "r")
 
-    f_scaling = "/sys/devices/system/cpu/cpu%s/cpufreq/cpuinfo_%s_freq"
+    f_scaling = "/sys/devices/system/cpu/cpu%s/cpufreq/%s_freq"
     f_scaling_min  = dict([])
     f_scaling_max  = dict([])
     f_scaling_cur  = dict([])
-    for cpu in glob.glob("/sys/devices/system/cpu/cpu[0-9]*/cpufreq/cpuinfo_cur_freq"):
-        m = re.match("/sys/devices/system/cpu/cpu([0-9]*)/cpufreq/cpuinfo_cur_freq", cpu)
+    for cpu in glob.glob("/sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_cur_freq"):
+        m = re.match("/sys/devices/system/cpu/cpu([0-9]*)/cpufreq/scaling_cur_freq", cpu)
         if not m:
             continue
         cpu_no = m.group(1)
         sys.stderr.write(f_scaling % (cpu_no,"min"))
-        f_scaling_min[cpu_no] = open(f_scaling % (cpu_no,"min"), "r")
-        f_scaling_max[cpu_no] = open(f_scaling % (cpu_no,"max"), "r")
-        f_scaling_cur[cpu_no] = open(f_scaling % (cpu_no,"cur"), "r")
+        f_scaling_min[cpu_no] = open(f_scaling % (cpu_no,"cpuinfo_min"), "r")
+        f_scaling_max[cpu_no] = open(f_scaling % (cpu_no,"cpuinfo_max"), "r")
+        f_scaling_cur[cpu_no] = open(f_scaling % (cpu_no,"scaling_cur"), "r")
 
     numastats = find_sysfs_numa_stats()
     utils.drop_privileges()


### PR DESCRIPTION
On Debian Wheezy `procstats.py` was failing to run.
Investigation showed that required file `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq` was not readable by `tcollector` user.

The filetree looks like this on `Debian 3.2.57-3+deb7u2 x86_64 GNU/Linux`:

```
# ls -l /sys/devices/system/cpu/cpu0/cpufreq/
-r--r--r-- 1 root root 4096 Oct  7 10:54 affected_cpus
-r--r--r-- 1 root root 4096 Oct  7 10:54 bios_limit
-r-------- 1 root root 4096 Oct  2 17:29 cpuinfo_cur_freq
-r--r--r-- 1 root root 4096 Oct  2 17:29 cpuinfo_max_freq
-r--r--r-- 1 root root 4096 Oct  2 17:29 cpuinfo_min_freq
-r--r--r-- 1 root root 4096 Oct  7 10:54 cpuinfo_transition_latency
-r--r--r-- 1 root root 4096 Oct  7 10:54 related_cpus
-r--r--r-- 1 root root 4096 Oct  7 10:54 scaling_available_frequencies
-r--r--r-- 1 root root 4096 Oct  7 10:54 scaling_available_governors
-r--r--r-- 1 root root 4096 Oct  7 10:54 scaling_cur_freq
-r--r--r-- 1 root root 4096 Oct  7 10:54 scaling_driver
-rw-r--r-- 1 root root 4096 Oct  7 10:54 scaling_governor
-rw-r--r-- 1 root root 4096 Oct  7 10:54 scaling_max_freq
-rw-r--r-- 1 root root 4096 Oct  7 10:54 scaling_min_freq
-rw-r--r-- 1 root root 4096 Oct  7 10:54 scaling_setspeed
```

The reason for that can be found in following mailing list post:
http://www.spinics.net/lists/cpufreq/msg02104.html

As stated there the change of permissions was made according to possible security issues.
They recommend to use `scaling_cur_freq` instead: "scaling_cur_freq differs from
cpuinfo_cur_freq _only_ if something is broken."
