### PR TITLE
Add missing reconnectinterval parameter in tests.py

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -61,7 +61,7 @@ class TSDBlacklistingTests(unittest.TestCase):
         tcollector.random.shuffle = self.random_shuffle
 
     def mkSenderThread(self, tsds):
-        return tcollector.SenderThread(None, True, tsds, False, {})
+        return tcollector.SenderThread(None, True, tsds, False, {}, reconnectinterval=5)
 
     def test_blacklistOneConnection(self):
         tsd = ("localhost", 4242)


### PR DESCRIPTION
Introduction of reconnect option (commit a71811b07e2848bef006c487aa0d7314c083b2c5) broke several tests, as SenderThread-creation in tests.py was not updated accordingly.
