### PR TITLE
When parsing redis port, get last element after ':' instead of second

### DIFF
--- a/collectors/0/redis-stats.py
+++ b/collectors/0/redis-stats.py
@@ -166,7 +166,7 @@ def scan_for_instances():
         if not (line and 'redis-server' in line):
             continue
         pid = int(line.split()[6].split("/")[0])
-        port = int(line.split()[3].split(":")[1])
+        port = int(line.split()[3].split(":")[-1])
 
         # now we have to get the command line.  we look in the redis config file for
         # a special line that tells us what cluster this is.  else we default to using


### PR DESCRIPTION
The token parsed from netstat can take one of two forms: "0 0.0.0.0:6379" and ":::6379".  If the for-loop hits the latter line first, then the line throws an exception.  This modification ensures that both formats are supported.

I'm running this collector on `Linux 3.2.30-49.59.amzn1.x86_64` EC2 box in AWS.

```
$ netstat --version
net-tools 1.60
netstat 1.42 (2001-04-15)
```

Here is an example output of the netstat command:

```
$ sudo netstat -tnlp
tcp        0      0 0.0.0.0:6379            0.0.0.0:*               LISTEN      7621/redis-server *
tcp6       0      0 :::6379                 :::*                    LISTEN      7621/redis-server *
```
