### PR TITLE
Add err to Utils mock, fixes udp_bridge test

### DIFF
--- a/mocks.py
+++ b/mocks.py
@@ -76,3 +76,6 @@ class Sys():
 class Utils():
     def __init__(self):
         self.drop_privileges = lambda: None
+
+    def err(self, msg):
+        sys.stderr.write("%s\n" % msg)


### PR DESCRIPTION
Changes to udp_bridge.py in commit ef41a852da9a3d20b4e426ac676e242ab10a83ed breaks a few tests in tests.py. Added err method to mock of utils module.
