### PR TITLE
Add TLS encryption support for TSD connections

### DIFF
--- a/debian/tcollector.init
+++ b/debian/tcollector.init
@@ -11,6 +11,7 @@
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/bin/tcollector
 EXTRA_TAGS=""
+EXTRA_ARGS=""
 
 . /lib/lsb/init-functions
 
@@ -70,7 +71,8 @@ case $1 in
             -t host=$HOSTNAME --dedup-interval $DEDUP_INTERVAL\
             --reconnect-interval $RECONNECT_INTERVAL\
             --max-bytes $LOGFILE_MAX_BYTES --backup-count $LOGFILE_BACKUP_COUNT\
-            --evict-interval $EVICT_INTERVAL -P "$PIDFILE" -D $EXTRA_TAGS_OPTS
+            --evict-interval $EVICT_INTERVAL $EXTRA_ARGS\
+			-P "$PIDFILE" -D $EXTRA_TAGS_OPTS
 
         log_end_msg $?
         ;;

--- a/rpm/initd.sh
+++ b/rpm/initd.sh
@@ -28,6 +28,7 @@ LOGFILE=${LOGFILE-/var/log/tcollector.log}
 LOGFILE_MAX_BYTES=${LOGFILE_MAX_BYTES-67108864}
 LOGFILE_BACKUP_COUNT=${LOGFILE_BACKUP_COUNT-0}
 RECONNECT_INTERVAL=${RECONNECT_INTERVAL-0}
+EXTRA_ARGS=""
 
 prog=tcollector
 if [ -f /etc/sysconfig/$prog ]; then
@@ -51,7 +52,7 @@ if [ -z "$OPTIONS" ]; then
   OPTIONS="$OPTIONS -t host=$THIS_HOST -P $PIDFILE"
   OPTIONS="$OPTIONS --reconnect-interval $RECONNECT_INTERVAL"
   OPTIONS="$OPTIONS --max-bytes $LOGFILE_MAX_BYTES --backup-count $LOGFILE_BACKUP_COUNT"
-  OPTIONS="$OPTIONS --logfile $LOGFILE $EXTRA_TAGS_OPTS"
+  OPTIONS="$OPTIONS --logfile $LOGFILE $EXTRA_ARGS $EXTRA_TAGS_OPTS"
 fi
 
 sanity_check() {


### PR DESCRIPTION
- Enable TLS encryption on TSD connections with command line
  toggle --tls or --ssl. Since OpenTSDB does not support SSL,
  this requires a SSL proxy in front of OpenTSDB, such as
  stunnel or similar
- Prefers TLS v1.2 if available (since python 2.7.9), uses
  TLS v1 otherwise
- Add _valid_certificate_name method to SenderThread, for
  verifying certificate name against hostname. Allows use of
  wildcard (*) in subdomains, but not in TLD or HOST parts.
  I.e. *.example.tld allowed
- Add command line option --ca-certs for specifying the path
  to the system ca-certificates file. Checks existence on
  start up. Defaults to /etc/ssl/certs/ca-certificates.crt
- Add EXTRA_ARGS option to init scripts, for specifying extra
  options like --tls and --ca-certs
