### PR TITLE
allow multiple configurable elasticsearch nodes

### DIFF
--- a/collectors/etc/elasticsearch_conf.py
+++ b/collectors/etc/elasticsearch_conf.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+# This file is part of tcollector.
+# Copyright (C) 2015  The tcollector Authors.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+# General Public License for more details.  You should have received a copy
+# of the GNU Lesser General Public License along with this program.  If not,
+# see <http://www.gnu.org/licenses/>.
+
+def get_servers():
+  """Get the ElasticSearch servers on this host.
+
+  Returns:
+    An iterable of tuples of (host, port)
+  """
+  return [ ("localhost", 9200) ]
+


### PR DESCRIPTION
This change allows you to monitor multiple elasticsearch nodes from one
tcollector instance if, for example, you have two nodes on one host, or
want to monitor nodes remotely.