### PR TITLE
fix shebang line to find the first python on PATH

### DIFF
--- a/collectors/0/dfstat.py
+++ b/collectors/0/dfstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010-2013  The tcollector Authors.
 #

--- a/collectors/0/elasticsearch.py
+++ b/collectors/0/elasticsearch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2011-2013  The tcollector Authors.
 #

--- a/collectors/0/eos.py
+++ b/collectors/0/eos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2014  The tcollector Authors.
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/collectors/0/flume.py
+++ b/collectors/0/flume.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
     flume stats collector

--- a/collectors/0/graphite_bridge.py
+++ b/collectors/0/graphite_bridge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2013  The tcollector Authors.
 #

--- a/collectors/0/hadoop_datanode.py
+++ b/collectors/0/hadoop_datanode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010  The tcollector Authors.
 #

--- a/collectors/0/hadoop_namenode.py
+++ b/collectors/0/hadoop_namenode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010  The tcollector Authors.
 #

--- a/collectors/0/hbase_master.py
+++ b/collectors/0/hbase_master.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010  The tcollector Authors.
 #

--- a/collectors/0/hbase_regionserver.py
+++ b/collectors/0/hbase_regionserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010  The tcollector Authors.
 #

--- a/collectors/0/ifstat.py
+++ b/collectors/0/ifstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010-2013  The tcollector Authors.
 #

--- a/collectors/0/iostat.py
+++ b/collectors/0/iostat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010  The tcollector Authors.
 #

--- a/collectors/0/mongo.py
+++ b/collectors/0/mongo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # mongo.py -- a MongoDB collector for tcollector/OpenTSDB
 # Copyright (C) 2013  The tcollector Authors.

--- a/collectors/0/netstat.py
+++ b/collectors/0/netstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2011  The tcollector Authors.
 #

--- a/collectors/0/nfsstat.py
+++ b/collectors/0/nfsstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (C) 2012  The tcollector Authors.
 #

--- a/collectors/0/procnettcp.py
+++ b/collectors/0/procnettcp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010  The tcollector Authors.
 #

--- a/collectors/0/procstats.py
+++ b/collectors/0/procstats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010  The tcollector Authors.
 #

--- a/collectors/0/redis-stats.py
+++ b/collectors/0/redis-stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (C) 2011  The tcollector Authors.
 #

--- a/collectors/0/riak.py
+++ b/collectors/0/riak.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (C) 2011  The tcollector Authors.
 #

--- a/collectors/0/udp_bridge.py
+++ b/collectors/0/udp_bridge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2013  The tcollector Authors.
 #

--- a/collectors/0/varnishstat.py
+++ b/collectors/0/varnishstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2013  The tcollector Authors.
 #

--- a/collectors/0/zfsiostats.py
+++ b/collectors/0/zfsiostats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2012  The tcollector Authors.
 #

--- a/collectors/0/zfskernstats.py
+++ b/collectors/0/zfskernstats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2012  The tcollector Authors.
 #

--- a/collectors/0/zookeeper.py
+++ b/collectors/0/zookeeper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """ 
 Zookeeper collector

--- a/collectors/etc/config.py
+++ b/collectors/etc/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010  The tcollector Authors.
 #

--- a/collectors/lib/hadoop_http.py
+++ b/collectors/lib/hadoop_http.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2011-2013  The tcollector Authors.
 #

--- a/collectors/lib/utils.py
+++ b/collectors/lib/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2013  The tcollector Authors.
 #

--- a/tcollector.py
+++ b/tcollector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010  The tcollector Authors.
 #

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2013  The tcollector Authors.
 #


### PR DESCRIPTION
If /usr/bin/python comes with the OS, it could be wildly out-of-date,
causing strange errors when spawning collectors like:

    Traceback (most recent call last):
      File "collectors/0/hbase_regionserver.py", line 24, in ?
        from collectors.lib.hadoop_http import HadoopHttp
      File "collectors/lib/hadoop_http.py", line 47
        finally:
              ^
    SyntaxError: invalid syntax

Even if tcollector.py is started with a modern Python.

Fixing the #! lines to use /usr/bin/env ensures that the first python on the
PATH is used.