### PR TITLE
Removed auto start & chkconfig on for tcollector RPM build

### DIFF
--- a/rpm/linux.spec
+++ b/rpm/linux.spec
@@ -1,8 +1,6 @@
 %post
 if [ "$1" = 1 ]; then
   chkconfig --add tcollector
-  chkconfig tcollector on
-  service tcollector start
 fi
 %preun
 if [ "$1" = 0 ]; then


### PR DESCRIPTION
tcollector should be installed without auto-launching and adding tcollector to default runlevels on startup. 