### PR TITLE
Make zookeeper collector py26 compatible and bugfixes

### DIFF
--- a/collectors/0/zookeeper.py
+++ b/collectors/0/zookeeper.py
@@ -10,7 +10,7 @@ http://zookeeper.apache.org/doc/trunk/zookeeperAdmin.html#sc_zkCommands
 import sys
 import socket
 import time
-import subprocess
+from subprocess import Popen, PIPE, CalledProcessError
 import re
 from collectors.lib import utils
 
@@ -47,10 +47,16 @@ def scan_zk_instances():
 
     instances = []
     try:
-        listen_sock = subprocess.check_output(["netstat", "-lnpt"], stderr=subprocess.PIPE)
-    except subprocess.CalledProcessError:
-        utils.err("netstat directory doesn't exist in PATH variable")
+        netstat = Popen(["netstat", "-lnpt"], stderr=PIPE, stdout=PIPE)
+        ret = netstat.wait()
+        if ret:
+            raise CalledProcessError("netstat returned code %i" % ret)
+        listen_sock = netstat.stdout.read()
+    except OSError:
+        utils.err("netstat is not in PATH")
         return instances
+    except CalledProcessError, err:
+        utils.err("Error: %s" % err)
 
     for line in listen_sock.split("\n"):
         if not "java" in line:
@@ -67,24 +73,22 @@ def scan_zk_instances():
             fd = open("/proc/%d/cmdline" % pid)
             cmdline = fd.readline()
             if "org.apache.zookeeper.server.quorum.QuorumPeerMain" in cmdline:
+                data = None
                 try:
-                    if tcp_version == "tcp6":
-                        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-                    else:
-                        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    sock = connect_socket(tcp_version, port)
                     sock.settimeout(0.5)
-                    sock.connect((ip, port))
                     sock.send("ruok\n")
                     data = sock.recv(1024)
-                except:
-                    pass
+                except Exception, err:
+                    utils.err(err)
                 finally:
-                    sock.close()
+                    if sock: 
+                        sock.close()
                 if data == "imok":	
                     instances.append([ip, port, tcp_version])
                     data = ""
-        except:
-            continue
+        except Exception, err:
+            utils.err(err)
         finally:
             fd.close()
     return instances 
@@ -93,12 +97,25 @@ def print_stat(metric, ts, value, tags=""):
     if value is not None:
         print "zookeeper.%s %i %s %s" % (metric, ts, value, tags)
 
+def connect_socket(tcp_version, port):
+    sock = None
+    if tcp_version == "tcp6":
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        ipaddr = '::1'
+    else:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        ipaddr = '127.0.0.1'
+    try:
+        sock.connect((ipaddr, port))
+    except Exception, err:
+        util.err(err)
+    return sock
+
 def main():
     if USER != "root":
         utils.drop_privileges(user=USER)
 
-    last_scan = time.time()
-    instances = scan_zk_instances()
+    last_scan = time.time() - SCAN_INTERVAL
 
     while True:
         ts = time.time()
@@ -114,16 +131,10 @@ def main():
         # Iterate over every zookeeper instance and get statistics
         for ip, port, tcp_version in instances:
             tags = "port=%s" % port
-            if tcp_version == "tcp6":
-                sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-            else:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                sock.connect((ip, port))
-            except:
-                utils.err("ZK Instance listening at port %d went away" % port)
-                instances.remove([ip, port, tcp_version])
-                break
+
+            sock = connect_socket(tcp_version, port)
+            if sock is None:
+                continue
 
             sock.send("mntr\n")
             data = sock.recv(1024)


### PR DESCRIPTION
The present zookeeper collector assumes python2.7. In addition to that, this change fixes 
- wrong assumptions made about exceptions being returned from subprocess,
- supplying incorrect localhost address for opening socket. 

BEFORE:
```
[root@oozie tcollector]# PYTHONPATH=. ./collectors/0/zookeeper.py 
Traceback (most recent call last):
  File "./collectors/0/zookeeper.py", line 140, in <module>
    sys.exit(main())	
  File "./collectors/0/zookeeper.py", line 101, in main
    instances = scan_zk_instances()
  File "./collectors/0/zookeeper.py", line 50, in scan_zk_instances
    listen_sock = subprocess.check_output(["netstat", "-lnpt"], stderr=subprocess.PIPE)
AttributeError: 'module' object has no attribute 'check_output'
```
AFTER:
```
[root@oozie tcollector]# PYTHONPATH=. ./collectors/0/zookeeper.py 
timed out
zookeeper.zk_avg_latency 1442708347 0 port=2181
zookeeper.zk_max_latency 1442708347 13 port=2181
zookeeper.zk_min_latency 1442708347 0 port=2181
zookeeper.zk_packets_received 1442708347 374 port=2181
zookeeper.zk_packets_sent 1442708347 373 port=2181
zookeeper.zk_num_alive_connections 1442708347 2 port=2181
zookeeper.zk_outstanding_requests 1442708347 0 port=2181
zookeeper.zk_approximate_data_size 1442708347 1217 port=2181
zookeeper.zk_open_file_descriptor_count 1442708347 23 port=2181
```