### PR TITLE
Error handle permissions errors in mysql collector.

### DIFF
--- a/collectors/0/mysql.py
+++ b/collectors/0/mysql.py
@@ -149,11 +149,11 @@ def find_sockfiles():
   paths = []
   # Look for socket files.
   for dir in SEARCH_DIRS:
-    if not os.path.isdir(dir):
+    if not os.path.isdir(dir) or not os.access(dir, os.R_OK):
       continue
     for name in os.listdir(dir):
       subdir = os.path.join(dir, name)
-      if not os.path.isdir(subdir):
+      if not os.path.isdir(subdir) or not os.access(subdir, os.R_OK):
         continue
       for subname in os.listdir(subdir):
         path = os.path.join(subdir, subname)


### PR DESCRIPTION
If dirs in SEARCH_DIRS are inaccessible, the collector crashes on start.

It is still able to do useful work by referencing DEFAULT_SOCKFILES but it doesn't get that far if it can't access /var/lib/mysql and/or subdirectories.