### PR TITLE
Added support for RunAbove IoT TimeSeries (hosted OpenTSDB)

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -61,7 +61,7 @@ class TSDBlacklistingTests(unittest.TestCase):
         tcollector.random.shuffle = self.random_shuffle
 
     def mkSenderThread(self, tsds):
-        return tcollector.SenderThread(None, True, tsds, False, False, False, {}, reconnectinterval=5, maxtags=8)
+        return tcollector.SenderThread(None, True, tsds, False, False, '', '', False, {}, reconnectinterval=5, maxtags=8)
 
     def test_blacklistOneConnection(self):
         tsd = ("localhost", 4242)


### PR DESCRIPTION
Uses the newly added HTTP support
fixes #225 
Tested with Python 2.6 and 2.7