### PR TITLE
Traverse the Elasticsearch JSON tree to automatically include any numeric values

### DIFF
--- a/collectors/0/elasticsearch.py
+++ b/collectors/0/elasticsearch.py
@@ -123,9 +123,9 @@ def _traverse(metric, stats, ts, tags):
     for value in stats:
       _traverse(metric + "." + str(count), value, ts, tags)
       count += 1
-  if utils.is_numeric(stats):
+  if utils.is_numeric(stats) and not isinstance(stats, bool):
     if isinstance(stats, int):
-      stats = int(stats) # handle bool and other "int"s
+      stats = int(stats)
     printmetric(metric, ts, stats, tags)
   return
 

--- a/collectors/0/elasticsearch.py
+++ b/collectors/0/elasticsearch.py
@@ -84,24 +84,43 @@ def node_stats(server, version):
     url = "/_nodes/_local/stats"
   return request(server, url)
 
-def printmetric(metric, ts, value, **tags):
+def printmetric(metric, ts, value, tags):
   if tags:
     tags = " " + " ".join("%s=%s" % (name, value)
                           for name, value in tags.iteritems())
   else:
     tags = ""
-  print ("elasticsearch.%s %d %s %s"
+  print ("%s %d %s %s"
          % (metric, ts, value, tags))
+
+def _traverse(metric, stats, ts, tags):
+  #print metric,stats,ts,tags
+  if isinstance(stats,dict):
+    if "timestamp" in stats:
+      ts = stats["timestamp"] / 1000 # ms -> s
+    for key in stats.keys():
+      if key != "timestamp":
+        _traverse(metric + "." + key, stats[key], ts, tags)
+  if isinstance(stats, (list, set, tuple)):
+    count = 0
+    for value in stats:
+      _traverse(metric + "." + str(count), value, ts, tags)
+      count += 1
+  if utils.is_numeric(stats):
+    printmetric(metric, ts, stats, tags)
+  return
 
 def _collect_server(server, version):
   ts = int(time.time())
+  rootmetric = "elasticsearch"
   nstats = node_stats(server, version)
   cluster_name = nstats["cluster_name"]
   nodeid, nstats = nstats["nodes"].popitem()
   node_name = nstats["name"]
+  tags = {"cluster": cluster_name, "node": node_name}
 
   is_master = nodeid == cluster_state(server)["master_node"]
-  printmetric("is_master", ts, int(is_master), node=node_name, cluster=cluster_name)
+  printmetric(rootmetric + ".is_master", ts, int(is_master), tags)
   if is_master:
     ts = int(time.time())  # In case last call took a while.
     cstats = cluster_health(server)
@@ -110,117 +129,9 @@ def _collect_server(server, version):
         value = STATUS_MAP.get(value, -1)
       elif not utils.is_numeric(value):
         continue
-      printmetric("cluster." + stat, ts, value, cluster=cluster_name)
+      printmetric(rootmetric + ".cluster." + stat, ts, value, tags)
 
-  if "os" in nstats:
-     ts = nstats["os"]["timestamp"] / 1000  # ms -> s
-  if "timestamp" in nstats:
-     ts = nstats["timestamp"] / 1000  # ms -> s
-
-  if "indices" in nstats:
-     indices = nstats["indices"]
-     if  "docs" in indices:
-        printmetric("num_docs", ts, indices["docs"]["count"], node=node_name, cluster=cluster_name)
-     if  "store" in indices:
-        printmetric("indices.size", ts, indices["store"]["size_in_bytes"], node=node_name, cluster=cluster_name)
-     if  "indexing" in indices:
-        d = indices["indexing"]
-        printmetric("indexing.index_total", ts, d["index_total"], node=node_name, cluster=cluster_name)
-        printmetric("indexing.index_time", ts, d["index_time_in_millis"], node=node_name, cluster=cluster_name)
-        printmetric("indexing.index_current", ts, d["index_current"], node=node_name, cluster=cluster_name)
-        printmetric("indexing.delete_total", ts, d["delete_total"], node=node_name, cluster=cluster_name)
-        printmetric("indexing.delete_time_in_millis", ts, d["delete_time_in_millis"], node=node_name, cluster=cluster_name)
-        printmetric("indexing.delete_current", ts, d["delete_current"], node=node_name, cluster=cluster_name)
-        del d
-     if  "get" in indices:
-        d = indices["get"]
-        printmetric("get.total", ts, d["total"], node=node_name, cluster=cluster_name)
-        printmetric("get.time", ts, d["time_in_millis"], node=node_name, cluster=cluster_name)
-        printmetric("get.exists_total", ts, d["exists_total"], node=node_name, cluster=cluster_name)
-        printmetric("get.exists_time", ts, d["exists_time_in_millis"], node=node_name, cluster=cluster_name)
-        printmetric("get.missing_total", ts, d["missing_total"], node=node_name, cluster=cluster_name)
-        printmetric("get.missing_time", ts, d["missing_time_in_millis"], node=node_name, cluster=cluster_name)
-        del d
-     if  "search" in indices:
-        d = indices["search"]
-        printmetric("search.query_total", ts, d["query_total"], node=node_name, cluster=cluster_name)
-        printmetric("search.query_time", ts, d["query_time_in_millis"], node=node_name, cluster=cluster_name)
-        printmetric("search.query_current", ts, d["query_current"], node=node_name, cluster=cluster_name)
-        printmetric("search.fetch_total", ts, d["fetch_total"], node=node_name, cluster=cluster_name)
-        printmetric("search.fetch_time", ts, d["fetch_time_in_millis"], node=node_name, cluster=cluster_name)
-        printmetric("search.fetch_current", ts, d["fetch_current"], node=node_name, cluster=cluster_name)
-        del d
-     if "cache" in indices:
-        d = indices["cache"]
-        printmetric("cache.field.evictions", ts, d["field_evictions"], node=node_name, cluster=cluster_name)
-        printmetric("cache.field.size", ts, d["field_size_in_bytes"], node=node_name, cluster=cluster_name)
-        printmetric("cache.filter.count", ts, d["filter_count"], node=node_name, cluster=cluster_name)
-        printmetric("cache.filter.evictions", ts, d["filter_evictions"], node=node_name, cluster=cluster_name)
-        printmetric("cache.filter.size", ts, d["filter_size_in_bytes"], node=node_name, cluster=cluster_name)
-        del d
-     if "merges" in indices:
-        d = indices["merges"]
-        printmetric("merges.current", ts, d["current"], node=node_name, cluster=cluster_name)
-        printmetric("merges.total", ts, d["total"], node=node_name, cluster=cluster_name)
-        printmetric("merges.total_time", ts, d["total_time_in_millis"] / 1000., node=node_name, cluster=cluster_name)
-        del d
-     del indices
-  if "process" in nstats:
-     process = nstats["process"]
-     ts = process["timestamp"] / 1000  # ms -> s
-     open_fds = process.get("open_file_descriptors")  # ES 0.17
-     if open_fds is None:
-       open_fds = process.get("fd")  # ES 0.16
-       if open_fds is not None:
-         open_fds = open_fds["total"]
-     if open_fds is not None:
-       printmetric("process.open_file_descriptors", ts, open_fds, node=node_name, cluster=cluster_name)
-     if "cpu" in process:
-        d = process["cpu"]
-        printmetric("process.cpu.percent", ts, d["percent"], node=node_name, cluster=cluster_name)
-        printmetric("process.cpu.sys", ts, d["sys_in_millis"] / 1000., node=node_name, cluster=cluster_name)
-        printmetric("process.cpu.user", ts, d["user_in_millis"] / 1000., node=node_name, cluster=cluster_name)
-        del d
-     if "mem" in process:
-        d = process["mem"]
-        printmetric("process.mem.resident", ts, d["resident_in_bytes"], node=node_name, cluster=cluster_name)
-        printmetric("process.mem.shared", ts, d["share_in_bytes"], node=node_name, cluster=cluster_name)
-        printmetric("process.mem.total_virtual", ts, d["total_virtual_in_bytes"], node=node_name, cluster=cluster_name)
-        del d
-     del process
-  if "jvm" in nstats:
-     jvm = nstats["jvm"]
-     ts = jvm["timestamp"] / 1000  # ms -> s
-     if "mem" in jvm:
-        d = jvm["mem"]
-        printmetric("jvm.mem.heap_used", ts, d["heap_used_in_bytes"], node=node_name, cluster=cluster_name)
-        printmetric("jvm.mem.heap_committed", ts, d["heap_committed_in_bytes"], node=node_name, cluster=cluster_name)
-        printmetric("jvm.mem.non_heap_used", ts, d["non_heap_used_in_bytes"], node=node_name, cluster=cluster_name)
-        printmetric("jvm.mem.non_heap_committed", ts, d["non_heap_committed_in_bytes"], node=node_name, cluster=cluster_name)
-        del d
-     if "threads" in jvm:
-        d = jvm["threads"]
-        printmetric("jvm.threads.count", ts, d["count"], node=node_name, cluster=cluster_name)
-        printmetric("jvm.threads.peak_count", ts, d["peak_count"], node=node_name, cluster=cluster_name)
-        del d
-     for gc, d in jvm["gc"]["collectors"].iteritems():
-       printmetric("jvm.gc.collection_count", ts, d["collection_count"], gc=gc, node=node_name, cluster=cluster_name)
-       printmetric("jvm.gc.collection_time", ts,
-                   d["collection_time_in_millis"] / 1000., gc=gc, node=node_name, cluster=cluster_name)
-     del jvm
-     del d
-  if "network" in nstats:
-     for stat, value in nstats["network"]["tcp"].iteritems():
-       if utils.is_numeric(value):
-         printmetric("network.tcp." + stat, ts, value, node=node_name, cluster=cluster_name)
-     for stat, value in nstats["transport"].iteritems():
-       if utils.is_numeric(value):
-         printmetric("transport." + stat, ts, value, node=node_name, cluster=cluster_name)
-  # New in ES 0.17:
-  for stat, value in nstats.get("http", {}).iteritems():
-    if utils.is_numeric(value):
-      printmetric("http." + stat, ts, value, node=node_name, cluster=cluster_name)
-  del nstats
+  _traverse(rootmetric, nstats, ts, tags)
 
 def main(argv):
   utils.drop_privileges()


### PR DESCRIPTION
There are a number of metrics that are not exported by the current code. Also, metrics are renamed and slightly differ against the elastic search values. This code traverses the output of /_nodes/_local/stats and pulls every numeric metric out without changes.

Plus, less code is better code. :)

One serious caveat: the metrics names will be different so this is a breaking change.