### PR TITLE
Avoid picking new connection if we only have one host defined

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -758,7 +758,8 @@ class SenderThread(threading.Thread):
                                                       indent=4)
             return
 
-        self.pick_connection()
+	if((self.current_tsd == -1) or (len(self.hosts) > 1)):
+        	self.pick_connection()
         # print "Using server: %s:%s" % (self.host, self.port)
         # url = "http://%s:%s/api/put?details" % (self.host, self.port)
         # print "Url is %s" % url

--- a/tcollector.py
+++ b/tcollector.py
@@ -758,8 +758,8 @@ class SenderThread(threading.Thread):
                                                       indent=4)
             return
 
-	if((self.current_tsd == -1) or (len(self.hosts) > 1)):
-        	self.pick_connection()
+        if((self.current_tsd == -1) or (len(self.hosts) > 1)):
+            self.pick_connection()
         # print "Using server: %s:%s" % (self.host, self.port)
         # url = "http://%s:%s/api/put?details" % (self.host, self.port)
         # print "Url is %s" % url


### PR DESCRIPTION
Hello,

This pull request avoid picking new connection if we only have one host defined.
This avoids lines of log every ~15 seconds :
```
2016-02-25 21:59:32,499 tcollector[84137] INFO: Selected connection: my.tsdb.host:443
2016-02-25 21:59:47,994 tcollector[84137] INFO: No more healthy hosts, retry with previously blacklisted
2016-02-25 21:59:47,994 tcollector[84137] INFO: Selected connection: my.tsdb.host:443
2016-02-25 22:00:03,366 tcollector[84137] INFO: No more healthy hosts, retry with previously blacklisted
2016-02-25 22:00:03,366 tcollector[84137] INFO: Selected connection: my.tsdb.host:443
2016-02-25 22:00:17,721 tcollector[84137] INFO: No more healthy hosts, retry with previously blacklisted
```

Thank you !

Ben