### PR TITLE
Include eno and bond interfaces in ifstat collector

### DIFF
--- a/collectors/0/ifstat.py
+++ b/collectors/0/ifstat.py
@@ -56,7 +56,7 @@ def main():
         f_netdev.seek(0)
         ts = int(time.time())
         for line in f_netdev:
-            m = re.match("\s+(eth?\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|"
+            m = re.match("\s+(eth?\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|eno\d+|"
                          "p\d+p\d+_\d+/\d+|p\d+p\d+_\d+|p\d+p\d+):(.*)", line)
             if not m:
                 continue


### PR DESCRIPTION
On newer Centos7 physical machines, the default is predictible network interfaces naming which in my case doesn't match.