### PR TITLE
last_datapoint = invocation time for collectors

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -1346,6 +1346,9 @@ def spawn_collector(col):
     # other logic and it makes no sense to update the last spawn time if the
     # collector didn't actually start.
     col.lastspawn = int(time.time())
+    # Without setting last_datapoint here, a long running check (>15s) will be 
+    # killed by check_children() the first time check_children is called.
+    col.last_datapoint = col.lastspawn
     set_nonblocking(col.proc.stdout.fileno())
     set_nonblocking(col.proc.stderr.fileno())
     if col.proc.pid > 0:


### PR DESCRIPTION
We have a collector that occasionally takes ages to run (40-50 seconds), and sometimes a lot longer (600+ seconds).

Killing after 600 seconds is fine, but we found that tcollector.py kept killing this collector in check_children() for newly spawned collectors, as the last_datapoint was too old on every invocation of check_children. Also, because it was being killed off all the time, the last_datapoint obviously never got updated after it hit the 600s limit the first time.

The fix around this (well, a fix that works for us, at least) is to set the last_datapoint of a collector to the time it was spawned, rather than when the object was first created (which could be ages ago).
