### PR TITLE
Support systemd-style "predictable network interface names"

### DIFF
--- a/collectors/0/ifstat.py
+++ b/collectors/0/ifstat.py
@@ -56,8 +56,25 @@ def main():
         f_netdev.seek(0)
         ts = int(time.time())
         for line in f_netdev:
-            m = re.match("\s+(eth?\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|"
-                         "p\d+p\d+_\d+/\d+|p\d+p\d+_\d+|p\d+p\d+):(.*)", line)
+            m = re.match(r'''
+                \s+
+                (
+                    eth?\d+ |
+                    em\d+_\d+/\d+ | em\d+_\d+ | em\d+ |
+                    p\d+p\d+_\d+/\d+ | p\d+p\d+_\d+ | p\d+p\d+ |
+                    (?:   # Start of 'predictable network interface names'
+                        (?:en|sl|wl|ww)
+                        (?:
+                            b\d+ |           # BCMA bus
+                            c[0-9a-f]+ |     # CCW bus group
+                            o\d+(?:d\d+)? |  # On-board device
+                            s\d+(?:f\d+)?(?:d\d+)? |  # Hotplug slots
+                            x[0-9a-f]+ |     # Raw MAC address
+                            p\d+s\d+(?:f\d+)?(?:d\d+)? | # PCI geographic loc
+                            p\d+s\d+(?:f\d+)?(?:u\d+)*(?:c\d+)?(?:i\d+)? # USB
+                         )
+                    )
+                ):(.*)''', line, re.VERBOSE)
             if not m:
                 continue
             intf = m.group(1)


### PR DESCRIPTION
Some systemd-based systems (e.g. RHEL7) have moved to "predictable network interface names" which are designed to remain consistent as new interfaces are added or removed from a system. Alas, that means these systems end up with a complex patchwork of potential new interface names. This patch implements the "spec" as defined in the header of https://github.com/systemd/systemd/blob/master/src/udev/udev-builtin-net_id.c

This patch allows these "new" interface names to actually generate tcollector output.

See also https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/

The regex for interface names is now big and ugly, which is mitigated by using a multi-line "verbose" regex. Suggested improvements for the format of this regex welcomed. 