### PR TITLE
fix ifstat.py to work with new interface names

### DIFF
--- a/collectors/0/ifstat.py
+++ b/collectors/0/ifstat.py
@@ -56,8 +56,9 @@ def main():
         f_netdev.seek(0)
         ts = int(time.time())
         for line in f_netdev:
-            m = re.match("\s+(eth?\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|"
-                         "p\d+p\d+_\d+/\d+|p\d+p\d+_\d+|p\d+p\d+):(.*)", line)
+            m = re.match("\s*(eth?\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|"
+                         "p\d+p\d+_\d+/\d+|p\d+p\d+_\d+|p\d+p\d+|"
+                         "en[p|s]\d.*):(.*)", line)
             if not m:
                 continue
             intf = m.group(1)

--- a/collectors/0/ifstat.py
+++ b/collectors/0/ifstat.py
@@ -56,7 +56,7 @@ def main():
         f_netdev.seek(0)
         ts = int(time.time())
         for line in f_netdev:
-            m = re.match("\s*(eth?\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|"
+            m = re.match("^\s*(eth?\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|"
                          "p\d+p\d+_\d+/\d+|p\d+p\d+_\d+|p\d+p\d+|"
                          "en[p|s]\d.*):(.*)", line)
             if not m:


### PR DESCRIPTION
The NICs can be named various things in RHEL7/CentOS7 depending on the udev rules.
If an admin chooses to name them after physical slot, the NIC names end up as enpNsNfN or ensNfN.

This commit adds these new NIC names to ifstat.py.

Also, I've made the regex more specific by matching on the beginning of the string, rather than anywhere in the string, as I believe this is (slightly) more robust.