### PR TITLE
Adding buddying memory fragmentation and slab info stats for tcollector

### DIFF
--- a/collectors/0/buddyinfo.py
+++ b/collectors/0/buddyinfo.py
@@ -20,9 +20,9 @@ import socket
 from collectors.lib import utils
 from collectors.etc import buddyinfo_conf as config
 
-BUDDYINFO='/proc/buddyinfo'
-METRIC='proc.meminfo.buddyinfo'
-HOSTNAME=socket.gethostname()
+BUDDYINFO = '/proc/buddyinfo'
+METRIC = 'proc.meminfo.buddyinfo'
+HOSTNAME = socket.gethostname()
 
 CONFIG = config.get_config()
 COLLECTION_INTERVAL = CONFIG['interval']

--- a/collectors/0/buddyinfo.py
+++ b/collectors/0/buddyinfo.py
@@ -18,16 +18,21 @@ import time
 import socket
 
 from collectors.lib import utils
-
-COLLECTION_INTERVAL = 1  # second
+from collectors.etc import buddyinfo_conf as config
 
 BUDDYINFO='/proc/buddyinfo'
 METRIC='proc.meminfo.buddyinfo'
 HOSTNAME=socket.gethostname()
 
-def main():
+CONFIG = config.get_config()
+COLLECTION_INTERVAL = CONFIG['interval']
 
-    """buddyinfo main loop"""
+if not CONFIG['enabled']:
+    sys.stderr.write("Buddy info collector is not enabled")
+    sys.exit(13)
+
+def main():
+    """buddyinfo collector main loop"""
     utils.drop_privileges()
 
     while True:

--- a/collectors/0/buddyinfo.py
+++ b/collectors/0/buddyinfo.py
@@ -35,23 +35,25 @@ def main():
     """buddyinfo collector main loop"""
     utils.drop_privileges()
 
-    while True:
-        epoch = int(time.time())
-        try:
-            with open(BUDDYINFO,'r') as buddyinfo:
+    try:
+        with open(BUDDYINFO,'r') as buddyinfo:
+            while True:
+                buddyinfo.seek(0)
+                epoch = int(time.time())
                 for line in buddyinfo.readlines(): 
                     zonedata = line.strip().split()
                     node = int(zonedata[1].strip(','))
                     zone = zonedata[3]
                     for order,val in enumerate(zonedata[4:]):
-                        print("%s %s %s host=%s zone=%s node=%d order=%d" % (METRIC, epoch, val, HOSTNAME, zone, node, order))
+                        print("%s %s %s host=%s zone=%s node=%d order=%d" % 
+                            (METRIC, epoch, val, HOSTNAME, zone, node, order))
 
-        except IOError, e:
-            utils.err("error: can't open %s: %s" % (BUDDYINFO,e))
-            return 13 # Ask tcollector to not respawn us
+                sys.stdout.flush()
+                time.sleep(COLLECTION_INTERVAL)
 
-        sys.stdout.flush()
-        time.sleep(COLLECTION_INTERVAL)
+    except IOError, e:
+        utils.err("error: can't open %s: %s" % (BUDDYINFO,e))
+        return 13 # Ask tcollector to not respawn us
 
 if __name__ == "__main__":
     sys.stdin.close()

--- a/collectors/0/buddyinfo.py
+++ b/collectors/0/buddyinfo.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# This file is part of tcollector.
+# Copyright (C) 2010-2013  The tcollector Authors.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+# General Public License for more details.  You should have received a copy
+# of the GNU Lesser General Public License along with this program.  If not,
+# see <http://www.gnu.org/licenses/>.
+"""memory buddy info fragmentation counters for TSDB"""
+
+import sys
+import time
+import socket
+
+from collectors.lib import utils
+
+COLLECTION_INTERVAL = 1  # second
+
+BUDDYINFO='/proc/buddyinfo'
+METRIC='proc.meminfo.buddyinfo'
+HOSTNAME=socket.gethostname()
+
+def main():
+
+    """buddyinfo main loop"""
+    utils.drop_privileges()
+
+    while True:
+        epoch = int(time.time())
+        try:
+            with open(BUDDYINFO,'r') as buddyinfo:
+                for line in buddyinfo.readlines(): 
+                    zonedata = line.strip().split()
+                    node = int(zonedata[1].strip(','))
+                    zone = zonedata[3]
+                    for order,val in enumerate(zonedata[4:]):
+                        print("%s %s %s host=%s zone=%s node=%d order=%d" % (METRIC, epoch, val, HOSTNAME, zone, node, order))
+
+        except IOError, e:
+            utils.err("error: can't open %s: %s" % (BUDDYINFO,e))
+            return 13 # Ask tcollector to not respawn us
+
+        sys.stdout.flush()
+        time.sleep(COLLECTION_INTERVAL)
+
+if __name__ == "__main__":
+    sys.stdin.close()
+    sys.exit(main())
+

--- a/collectors/0/slabinfo.py
+++ b/collectors/0/slabinfo.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# This file is part of tcollector.
+# Copyright (C) 2010-2013  The tcollector Authors.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+# General Public License for more details.  You should have received a copy
+# of the GNU Lesser General Public License along with this program.  If not,
+# see <http://www.gnu.org/licenses/>.
+"""memory slab info fragmentation counters for TSDB"""
+
+import sys
+import time
+import socket
+
+from collectors.lib import utils
+from collectors.etc import slabinfo_conf as config
+
+SLABINFO = '/proc/slabinfo'
+METRIC = 'proc.meminfo.slabinfo'
+HOSTNAME = socket.gethostname()
+CONFIG = config.get_config()
+COLLECTION_INTERVAL = CONFIG['interval']
+
+if not CONFIG['enabled']:
+    sys.stderr.write("Slab info collector is not enabled")
+    sys.exit(13)
+
+def main():
+    """slabinfo collector main loop"""
+
+    try:
+        with open(SLABINFO,'r') as slabinfo:
+            utils.drop_privileges()
+            while True:
+                #slabinfo.seek(204)
+                slabinfo.seek(0)
+                epoch = int(time.time())
+                for line in slabinfo.readlines(): 
+                    if 'slabinfo - version' in line or '#name' in line:
+                        continue
+
+                    slabdata = line.strip().split()
+                    objname, active_objs, num_objs, objsize, objperslab, pagesperslab = slabdata[0:6]
+                    print("%s.active %s %s host=%s slab=%s objsize=%s" % 
+                            (METRIC, epoch, active_objs, HOSTNAME, objname, objsize))
+                    print("%s.numobjs %s %s host=%s slab=%s objsize=%s" % 
+                            (METRIC, epoch, num_objs, HOSTNAME, objname, objsize))
+
+                sys.stdout.flush()
+                time.sleep(COLLECTION_INTERVAL)
+
+    except IOError, e:
+        utils.err("error: can't open %s: %s" % (SLABINFO,e))
+        return 13 # Ask tcollector to not respawn us
+
+if __name__ == "__main__":
+    sys.stdin.close()
+    sys.exit(main())
+

--- a/collectors/etc/buddyinfo_conf.py
+++ b/collectors/etc/buddyinfo_conf.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+# This file is part of tcollector.
+# Copyright (C) 2015  The tcollector Authors.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+# General Public License for more details.  You should have received a copy
+# of the GNU Lesser General Public License along with this program.  If not,
+# see <http://www.gnu.org/licenses/>.
+
+def get_config():
+  config = {
+    'interval': 1,
+    'enabled': True
+  }
+  return config

--- a/collectors/etc/slabinfo_conf.py
+++ b/collectors/etc/slabinfo_conf.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+# This file is part of tcollector.
+# Copyright (C) 2015  The tcollector Authors.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+# General Public License for more details.  You should have received a copy
+# of the GNU Lesser General Public License along with this program.  If not,
+# see <http://www.gnu.org/licenses/>.
+
+def get_config():
+  config = {
+    'interval': 15,
+    'enabled': True
+  }
+  return config


### PR DESCRIPTION
Hi All,

Created two small collectors that collect stats on memory fragmentation (buddy info) and one that collects information on the number of active (and total) slab objects.

Not sure what the procedure would be to add them to the project, so submitting a pull request for evaluation.

Thanks,
Eduardo.