### PR TITLE
EOS tcollector agent improvements 

### DIFF
--- a/eos/tcollector_agent.py
+++ b/eos/tcollector_agent.py
@@ -234,6 +234,11 @@ class TcollectorAgent(eossdk.AgentHandler,
               "--host", self._get_tsd_host(),
               "--port", str(self._get_tsd_port()),
               "--collector-dir=/usr/local/tcollector/collectors"]
+
+      if self.get_agent_mgr().agent_option("dedup-interval"):
+          args.append("--dedup-interval=%s" %
+                      self.get_agent_mgr().agent_option("dedup-interval"))
+
       tcollector.socket.socket = self._socket_at
       debug("Starting tcollector", args)
       options, args = tcollector.parse_cmdline(args)
@@ -260,8 +265,6 @@ class TcollectorAgent(eossdk.AgentHandler,
          kwargs["http_username"] = self.get_agent_mgr().agent_option("username")
       if self.get_agent_mgr().agent_option("password"):
          kwargs["http_password"] = self.get_agent_mgr().agent_option("password")
-      if self.get_agent_mgr().agent_option("dedupinterval"):
-         kwargs["dedupinterval"] = self.get_agent_mgr().agent_option("dedupinterval")
       sender = tcollector.SenderThread(reader,
                                        options.dryrun,
                                        hosts,

--- a/rpm/tcollector.spec
+++ b/rpm/tcollector.spec
@@ -152,5 +152,6 @@ if [ $1 -eq 0 ] ; then
     rm -f %{tcollectordir}/collectors/0/agentcpu.sh
     rm -f %{tcollectordir}/collectors/0/agentmem.sh
     rm -f %{tcollectordir}/collectors/0/eos.py
-    rm -f %{py2_sitelib}/tcollector_agent.py
+    rm -f %{py2_sitelib}/tcollector_agent.py*
+
 fi


### PR DESCRIPTION
Add dedup interval to main args list
Remove tcollector_agent.py[c] during RPM uninstall