### PR TITLE
Make sure to use correct shebang everywhere

### DIFF
--- a/collectors/0/docker.py
+++ b/collectors/0/docker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # More informations on https://docs.docker.com/articles/runmetrics/
 """Imports Docker stats from /sys/fs/cgroup."""
 

--- a/collectors/0/g1gc.py
+++ b/collectors/0/g1gc.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2013  The tcollector Authors.
 #

--- a/collectors/0/tcollector.py
+++ b/collectors/0/tcollector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2013  ProfitBricks GmbH
 

--- a/collectors/300/aws_cloudwatch_stats.py
+++ b/collectors/300/aws_cloudwatch_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import os
 import sys
 import time

--- a/collectors/etc/config.py
+++ b/collectors/etc/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2010  The tcollector Authors.
 #

--- a/collectors/etc/couchbase_conf.py
+++ b/collectors/etc/couchbase_conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2015  The tcollector Authors.
 #

--- a/collectors/etc/docker_conf.py
+++ b/collectors/etc/docker_conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2015  The tcollector Authors.
 #

--- a/collectors/etc/elasticsearch_conf.py
+++ b/collectors/etc/elasticsearch_conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2015  The tcollector Authors.
 #

--- a/collectors/etc/mongodb3_conf.py
+++ b/collectors/etc/mongodb3_conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # This file is part of tcollector.
 # Copyright (C) 2016  The tcollector Authors.

--- a/collectors/etc/redis_stats_conf.py
+++ b/collectors/etc/redis_stats_conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2015  The tcollector Authors.
 #

--- a/collectors/lib/hadoop_http.py
+++ b/collectors/lib/hadoop_http.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2011-2013  The tcollector Authors.
 #

--- a/collectors/lib/utils.py
+++ b/collectors/lib/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2013  The tcollector Authors.
 #

--- a/eos/collectors/eos.py
+++ b/eos/collectors/eos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (C) 2014  The tcollector Authors.
 #
 # This program is free software: you can redistribute it and/or modify it

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of tcollector.
 # Copyright (C) 2013  The tcollector Authors.
 #

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # This file is part of tcollector.
 # Copyright (C) 2013  The tcollector Authors.
 #


### PR DESCRIPTION
Hello,

This PR corrects the last wrong shebangs, replacing them by :
`/usr/bin/env python`

Thank you 👍 

Ben