### PR TITLE
changed regex to match interface name without leading blanks in "/proc/net/dev"

### DIFF
--- a/collectors/0/ifstat.py
+++ b/collectors/0/ifstat.py
@@ -57,7 +57,7 @@ def main():
         ts = int(time.time())
         for line in f_netdev:
             m = re.match(r'''
-                \s+
+                \s*
                 (
                     eth?\d+ |
                     em\d+_\d+/\d+ | em\d+_\d+ | em\d+ |


### PR DESCRIPTION
met the problem that one network interface can not be matched and found out the output from "/proc/net/dev" with the interface doesn't has leading blanks.
something like
# cat /proc/net/dev
Inter-|   Receive                                                |  Transmit
 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
enp0s31f6: 30961759505 35569059    0 694524    0     0          0     22699 20341346741 29169231    0    0    0     0       0          0
    lo: 8883814369 4766739    0    0    0     0          0         0 8883814369 4766739    0    0    0     0       0          0
virbr0-nic:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
virbr0:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0

changed the regex from \s+ to \s*