### PR TITLE
Correct issues with zfsiostats

### DIFF
--- a/collectors/etc/zfsiostats_conf.py
+++ b/collectors/etc/zfsiostats_conf.py
@@ -4,7 +4,8 @@ def get_config():
 
     config = {
         'collection_interval': 15,             # Seconds, how often to collect metric data
-        'report_capacity_every_x_times': 20    # Avoid reporting capacity info too frequently, 0 disables capacity reporting
+        'report_capacity_every_x_times': 20,   # Avoid reporting capacity info too frequently, 0 disables capacity reporting
+        'report_disks_in_vdevs': 0             # Avoid reporting statistics for disks which are part of vdevs
     }
 
     return config


### PR DESCRIPTION
Hello,

This PR solves some issues with zfsiostats collector :
- report usage stats as soon as the first loop ;
- do not report stats which do not exist (represented by a `-` in `zpool iostat` output) ;
- add an option (report_disks_in_vdevs, 0|1) to avoid reporting too much / useless data.

Thank you 👍 

Ben