### PR TITLE
Add docker engine collector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.6"
   - "2.7"
 install:
-  - pip install pylint ordereddict
+  - pip install pylint ordereddict requests feedparser prometheus_client
 script:
   - ./pylint-runner.py -s
   - ./tests.py

--- a/collectors/0/docker_engine.py
+++ b/collectors/0/docker_engine.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+"""Imports Docker stats from the docker-api"""
+
+import json
+import sys
+import time
+import requests
+
+from feedparser import _parse_date as parse_date
+from prometheus_client.parser import text_string_to_metric_families
+
+from collectors.etc import docker_engine_conf
+from collectors.lib import utils
+
+CONFIG = docker_engine_conf.get_config()
+COLLECTION_INTERVAL = CONFIG['interval']
+DEFAULT_DIMS = CONFIG['default_dims']
+ENABLED = docker_engine_conf.enabled()
+METRICS_PATH = CONFIG['metrics_path']
+
+if not ENABLED:
+  sys.stderr.write("Docker-engine collector is not enabled")
+  sys.exit(13)
+
+class Metric(object):
+    def __init__(self, name, etime, value, dims=None):
+        self.name = name
+        self.value = value
+        self.event_time = etime
+        if dims is None:
+            self.dims = set([])
+        else:
+            self.dims = set(dims)
+        self.dims.update(set(DEFAULT_DIMS))
+
+    def add_dims(self, dims):
+        self.dims.update(set(dims))
+
+    def getMetricLines(self):
+        """ return in OpenTSDB format
+        <name> <time_epoch> <value> [key=val] [key1=val1]...
+        """
+        m = "%s %s %s" % (self.name, int(time.mktime(self.event_time)), self.value)
+        return "%s %s" % (m, " ".join(sorted(list(self.dims))))
+
+class Stats(object):
+    def __init__(self, container, mtime):
+        self.dims = [
+            "container_name=%s" % trimContainerName(container),
+            "container_id=%s" % container['Id'],
+            "image_name=%s" % container['Image'],
+            "image_id=%s" % container['ImageID']
+        ]
+        self.event_time = mtime
+
+def trimContainerName(container):
+    return container["Names"][0].strip("/")
+
+def evalPrometheusLine(etime, line):
+    ret = []
+    for family in text_string_to_metric_families(line):
+        for sample in family.samples:
+            dims = []
+            for kv in sample[1].items():
+                dims.append("%s=%s" % kv)
+            m = Metric("docker.{0}".format(*sample), etime, sample[2], dims)
+            ret.append(m)
+    return ret
+
+class DockerMetrics(object):
+    def __init__(self, url):
+        self._url = url
+        self.event_time = time.gmtime()
+
+    def getEndpoint(self):
+        """ Fetches the endpoint """
+        ret = []
+        r = requests.get(self._url)
+        if r.status_code != 200:
+            print "Error %s: %s" % (r.status_code, r.text)
+        else:
+            for line in r.iter_lines():
+                if not line.startswith("#"):
+                    ret.extend(evalPrometheusLine(self.event_time, line))
+        return ret
+
+def main():
+    """docker_cpu main loop"""
+    cli = DockerMetrics(METRICS_PATH)
+
+    while True:
+        for m in cli.getEndpoint():
+            print m.getMetricLines()
+        break
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/collectors/etc/docker_engine_conf.py
+++ b/collectors/etc/docker_engine_conf.py
@@ -20,6 +20,6 @@ def get_config():
   config = {
     'interval': 15,
     'default_dims': '',
-    'metrics_path': 'http://192.168.100.10:3376/metrics'
+    'metrics_path': 'http://localhost:3376/metrics'
   }
   return config

--- a/collectors/etc/docker_engine_conf.py
+++ b/collectors/etc/docker_engine_conf.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# This file is part of tcollector.
+# Copyright (C) 2015  The tcollector Authors.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+# General Public License for more details.  You should have received a copy
+# of the GNU Lesser General Public License along with this program.  If not,
+# see <http://www.gnu.org/licenses/>.
+
+def enabled():
+  return True
+
+def get_config():
+  """Configuration for the Docker engine (Prometeus) collector """
+  config = {
+    'interval': 15,
+    'default_dims': '',
+    'metrics_path': 'http://192.168.100.10:3376/metrics'
+  }
+  return config

--- a/collectors/test/test_docker_engine.py
+++ b/collectors/test/test_docker_engine.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+import time
+import os
+import sys
+
+class _dummy(object):
+    pass
+me = os.path.split(os.path.realpath(sys.modules[_dummy.__module__].__file__))[0]
+sys.path.insert(0, os.path.join(os.path.split(me)[0], '0'))
+import docker_engine
+
+def test_trimContainerName():
+    cnt = {"Names": ["/name"]}
+    assert docker_engine.trimContainerName(cnt) == "name"
+
+def test_Metric():
+    """ Check assembly of metric """
+    now = time.gmtime()
+    m = docker_engine.Metric("metric", now, 10)
+    assert m.name == "metric"
+    assert m.value == 10
+    assert m.event_time == now
+    assert m.dims == set([])
+    m.add_dims(["hello=world"])
+    assert m.dims == set(["hello=world"])
+    got = m.getMetricLines()
+    assert got == "metric %s 10 hello=world" % int(time.mktime(now))
+
+
+def test_Stats():
+    """ Check if the constructor of Stats works correctly """
+    now = time.gmtime()
+    cnt = {
+        "Names": ["/name"],
+        "Id": "cntHASH",
+        "Image": "qnib/test",
+        "ImageID": "sha256:123"
+    }
+    exp_dims = [
+        "container_name=name",
+        "container_id=cntHASH",
+        "image_name=qnib/test",
+        "image_id=sha256:123"
+    ]
+    s = docker_engine.Stats(cnt, now)
+    assert s.dims == exp_dims
+    assert s.event_time == now
+
+def test_evalPrometheusLine():
+    # Prometheus line
+    now = time.gmtime()
+    line = 'engine_daemon_network_actions_seconds_count{action="connect"} 2'
+    gotMetric = docker_engine.evalPrometheusLine(now, line)
+    got = gotMetric[0].getMetricLines()
+    exp = "docker.engine_daemon_network_actions_seconds_count %s 2.0 action=connect" % int(time.mktime(now))
+    assert exp == got


### PR DESCRIPTION
Collector to fetch /metrics endpoint of experimental `metrics-addr` feature.

```
rootdir: ./src/github.com/ChristianKniep/tcollector, inifile:
plugins: cov-2.4.0
collected 4 items

collectors/test/test_docker_engine.py ....

---------- coverage: platform darwin, python 2.7.12-final-0 ----------
Name                            Stmts   Miss  Cover
---------------------------------------------------
collectors/0/docker_engine.py      68     18    74%
```
Example output:

```
$ python collectors/0/docker_engine.py
docker.engine_daemon_container_actions_seconds_bucket 1481211084 1.0 action=changes le=0.005
docker.engine_daemon_container_actions_seconds_bucket 1481211084 1.0 action=changes le=0.01
*snip*
docker.engine_daemon_engine_cpus_cpus 1481211084 2.0
docker.engine_daemon_engine_info 1481211084 1.0 architecture=x86_64 commit=88a45c4 graph_driver=aufs kernel=4.4.0-38-generic os=Ubuntu 16.04.1 LTS version=1.13.0-rc1
docker.engine_daemon_engine_memory_bytes 1481211084 4143755264.0
docker.engine_daemon_events_subscribers_total 1481211084 0.0
docker.engine_daemon_events_total 1481211084 8.0
docker.engine_daemon_health_checks_failed_total 1481211084 0.0
docker.engine_daemon_health_checks_total 1481211084 0.0
*snip*
```