### PR TITLE
Add option for specifying HTTP endpoint URL path

### DIFF
--- a/collectors/etc/config.py
+++ b/collectors/etc/config.py
@@ -62,6 +62,7 @@ def get_defaults():
         'port': 4242,
         'pidfile': '/var/run/tcollector.pid',
         'http': False,
+        'http_api_path': "api/put",
         'tags': [],
         'remove_inactive_collectors': False,
         'host': 'localhost',

--- a/tcollector.py
+++ b/tcollector.py
@@ -722,6 +722,16 @@ class SenderThread(threading.Thread):
         # FIXME: we should be reading the result at some point to drain
         # the packets out of the kernel's queue
 
+    def build_http_url(self):
+        if self.ssl:
+            protocol = "https"
+        else:
+            protocol = "http"
+        details=""
+        if LOG.level == logging.DEBUG:
+            details="?details"
+        return "%s://%s:%s/api/put%s" % (protocol, self.host, self.port, details)
+
     def send_data_via_http(self):
         """Sends outstanding data in self.sendq to TSD in one HTTP API call."""
         metrics = []
@@ -761,14 +771,8 @@ class SenderThread(threading.Thread):
 
         if((self.current_tsd == -1) or (len(self.hosts) > 1)):
             self.pick_connection()
-        if self.ssl:
-            protocol = "https"
-        else:
-            protocol = "http"
-        details=""
-        if LOG.level == logging.DEBUG:
-            details="?details"
-        url = "%s://%s:%s/api/put%s" % (protocol, self.host, self.port, details)
+
+        url = self.build_http_url()
         LOG.debug("Sending metrics to url", url)
         req = urllib2.Request(url)
         if self.http_username and self.http_password:

--- a/tcollector.py
+++ b/tcollector.py
@@ -418,7 +418,7 @@ class SenderThread(threading.Thread):
 
     def __init__(self, reader, dryrun, hosts, self_report_stats, tags,
                  reconnectinterval=0, http=False, http_username=None,
-                 http_password=None, ssl=False, maxtags=8):
+                 http_password=None, http_api_path=None, ssl=False, maxtags=8):
         """Constructor.
 
         Args:
@@ -439,6 +439,7 @@ class SenderThread(threading.Thread):
         self.reader = reader
         self.tags = sorted(tags.items()) # dictionary transformed to list
         self.http = http
+        self.http_api_path = http_api_path
         self.http_username = http_username
         self.http_password = http_password
         self.ssl = ssl
@@ -730,7 +731,7 @@ class SenderThread(threading.Thread):
         details=""
         if LOG.level == logging.DEBUG:
             details="?details"
-        return "%s://%s:%s/api/put%s" % (protocol, self.host, self.port, details)
+        return "%s://%s:%s/%s%s" % (protocol, self.host, self.port, self.http_api_path, details)
 
     def send_data_via_http(self):
         """Sends outstanding data in self.sendq to TSD in one HTTP API call."""
@@ -835,6 +836,7 @@ def parse_cmdline(argv):
             'port': 4242,
             'pidfile': '/var/run/tcollector.pid',
             'http': False,
+            'http_api_path': "api/put",
             'tags': [],
             'remove_inactive_collectors': False,
             'host': 'localhost',
@@ -928,6 +930,8 @@ def parse_cmdline(argv):
                         help='The maximum number of tags to send to our TSD Instances')
     parser.add_option('--http', dest='http', action='store_true', default=defaults['http'],
                         help='Send the data via the http interface')
+    parser.add_option('--http-api-path', dest='http_api_path', type='str',
+                      default=defaults['http_api_path'], help='URL path to use for HTTP requests to TSD.')
     parser.add_option('--http-username', dest='http_username', default=defaults['http_username'],
                       help='Username to use for HTTP Basic Auth when sending the data via HTTP')
     parser.add_option('--http-password', dest='http_password', default=defaults['http_password'],
@@ -1061,7 +1065,7 @@ def main(argv):
     sender = SenderThread(reader, options.dryrun, options.hosts,
                           not options.no_tcollector_stats, tags, options.reconnectinterval,
                           options.http, options.http_username,
-                          options.http_password, options.ssl, options.maxtags)
+                          options.http_password, options.http_api_path, options.ssl, options.maxtags)
     sender.start()
     LOG.info('SenderThread startup complete')
 

--- a/tcollector.py
+++ b/tcollector.py
@@ -761,20 +761,16 @@ class SenderThread(threading.Thread):
 
         if((self.current_tsd == -1) or (len(self.hosts) > 1)):
             self.pick_connection()
-        # print "Using server: %s:%s" % (self.host, self.port)
-        # url = "http://%s:%s/api/put?details" % (self.host, self.port)
-        # print "Url is %s" % url
         if self.ssl:
             protocol = "https"
         else:
             protocol = "http"
-        LOG.debug("Sending metrics to %s://%s:%s/api/put?details",
-                  protocol, self.host, self.port)
         details=""
         if LOG.level == logging.DEBUG:
             details="?details"
-        req = urllib2.Request("%s://%s:%s/api/put%s" % (
-            protocol, self.host, self.port, details))
+        url = "%s://%s:%s/api/put%s" % (protocol, self.host, self.port, details)
+        LOG.debug("Sending metrics to url", url)
+        req = urllib2.Request(url)
         if self.http_username and self.http_password:
           req.add_header("Authorization", "Basic %s"
                          % base64.b64encode("%s:%s" % (self.http_username, self.http_password)))


### PR DESCRIPTION
This depends on PR #358 (the first two commits). They're included here for completeness.

Comment copied from commit message which explains the rationale:

The option can be useful for cases where you need multiple tcollector
instances to report to different URLs to be able to differentiate between
them without having to add redundant data (via e.g. the "tag" option for
tcollector). In our use case we're proxying the requests to different TSD
instances.