### PR TITLE
Re-create sqlite index after table drop

### DIFF
--- a/collectors/0/zabbix_bridge.py
+++ b/collectors/0/zabbix_bridge.py
@@ -80,6 +80,7 @@ def main():
                                 print "tcollector.zabbix_bridge.key_lookup_miss_reload %d %s" % (sample_last_ts, (key_lookup_miss - last_key_lookup_miss))
                                 cachecur.execute('DROP TABLE zabbix_cache')
                                 cachecur.execute('CREATE TABLE zabbix_cache AS SELECT * FROM dbfile.zabbix_cache')
+                                cachecur.execute('CREATE UNIQUE INDEX uniq_zid on zabbix_cache (id)')
                                 last_key_lookup_miss = key_lookup_miss
                     else:
                         # TODO: Consider https://wiki.python.org/moin/PythonDecoratorLibrary#Retry


### PR DESCRIPTION
When the zabbix_cache table gets dropped (after $dbrefresh cache misses), so does the index.
Even if the table is in RAM, performance slows to a crawl without the index.