### PR TITLE
Fix `TypeError: unhashable type` when stripping off tags exceeding max

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -760,7 +760,7 @@ class SenderThread(threading.Thread):
             metric_entry["tags"] = dict(self.tags).copy()
             if len(metric_tags) + len(metric_entry["tags"]) > self.maxtags:
               metric_tags_orig = set(metric_tags)
-              subset_metric_keys = frozenset(metric_tags[:len(metric_tags[:self.maxtags-len(metric_entry["tags"])])])
+              subset_metric_keys = frozenset(metric_tags.keys()[:len(metric_tags.keys()[:self.maxtags-len(metric_entry["tags"])])])
               metric_tags = dict((k, v) for k, v in metric_tags.iteritems() if k in subset_metric_keys)
               LOG.error("Exceeding maximum permitted metric tags - removing %s for metric %s",
                         str(metric_tags_orig - set(metric_tags)), metric)


### PR DESCRIPTION
## Before:

```
2017-04-15 19:32:17,916 tcollector[13905] ERROR: Uncaught exception in SenderThread, going to exit
Traceback (most recent call last):
  File "/usr/local/tcollector/tcollector.py", line 522, in run
    self.send_data()
  File "/usr/local/tcollector/tcollector.py", line 691, in send_data
    return self.send_data_via_http()
  File "/usr/local/tcollector/tcollector.py", line 763, in send_data_via_http
    subset_metric_keys = frozenset(metric_tags[:len(metric_tags[:self.maxtags-len(metric_entry["tags"])])])
TypeError: unhashable type
2017-04-15 19:32:17,917 tcollector[13905] INFO: shutting down children
```

## After:

```
2017-04-15 19:54:08,818 tcollector[12387] ERROR: Exceeding maximum permitted metric tags - removing set(['service']) for metric proc.net.tcp
2017-04-15 19:54:08,818 tcollector[12387] ERROR: Exceeding maximum permitted metric tags - removing set(['service']) for metric proc.net.tcp
2017-04-15 19:54:08,819 tcollector[12387] ERROR: Exceeding maximum permitted metric tags - removing set(['service']) for metric proc.net.tcp
2017-04-15 19:54:08,819 tcollector[12387] INFO: Selected connection: <omitted>:4343
```