### PR TITLE
Removes additional whitespace from lines

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -325,6 +325,10 @@ class ReaderThread(threading.Thread):
         """Parses the given line and appends the result to the reader queue."""
 
         self.lines_collected += 1
+        # If the line contains more than a whitespace between
+        # parameters, it won't be interpeted.
+        while '  ' in line:
+            line = line.replace('  ', ' ')
 
         col.lines_received += 1
         if len(line) >= 1024:  # Limit in net.opentsdb.tsd.PipelineFactory


### PR DESCRIPTION
In case a line contains more than a whitespace between values, it will not be interpeted, it's better to simply replace any multiple occurrences with a single whitespace.