### PR TITLE
Fixed a minor bug in flume.py

### DIFF
--- a/collectors/0/flume.py
+++ b/collectors/0/flume.py
@@ -83,7 +83,7 @@ def main(argv):
   if (settings['default_timeout']):
     DEFAULT_TIMEOUT = settings['default_timeout']
 
-  if (settings['default_timeout']):
+  if (settings['collection_interval']):
     COLLECTION_INTERVAL = settings['collection_interval']
 
   if (settings['flume_host']):


### PR DESCRIPTION
Before getting 'collection_interval' from the config file, we need to check whether the value is available rather than checking 'default_timeout'.