### PR TITLE
replace deprecated build-dependency with new one

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Priority: optional
 Maintainer: Fabian Holler <fabian.holler@profitbricks.com>
 Standards-Version: 3.9.4
 Section: utils
-Build-Depends: debhelper ( >= 8 ), python-support
+Build-Depends: debhelper ( >= 8 ), dh-python
 vcs-Browser: https://github.com/OpenTSDB/tcollector
 Homepage: http://opentsdb.net/
 


### PR DESCRIPTION
python-support is deprecated and replaced by dh_python2 - python-support doesn't work on stretch for example
more info: https://wiki.debian.org/Python/TransitionToDHPython2
also fixing: https://github.com/OpenTSDB/tcollector/issues/370