### PR TITLE
collectors/0/nfsstat: correct list of nfs client names

### DIFF
--- a/collectors/0/nfsstat.py
+++ b/collectors/0/nfsstat.py
@@ -29,11 +29,14 @@ nfs_client_proc_names = {
         "lock", "lockt", "locku", "access", "getattr", "lookup", "lookup_root",
         "remove", "rename", "link", "symlink", "create", "pathconf", "statfs",
         "readlink", "readdir", "server_caps", "delegreturn", "getacl", "setacl",
-        "fs_locations", "rel_lkowner", "secinfo",
+        "fs_locations", "rel_lkowner", "secinfo", "fsid_present",
         # nfsv4.1 client ops
         "exchange_id", "create_ses", "destroy_ses", "sequence", "get_lease_t",
         "reclaim_comp", "layoutget", "getdevinfo", "layoutcommit", "layoutreturn",
-        "getdevlist", "getdevinfo", "ds_write", "ds_commit"
+        "secinfo_no", "test_stateid", "free_stateid",
+        "getdevicelist", "bind_conn_to_ses", "destroy_clientid",
+        # nfsv4.2 clientops
+        "seek", "allocate", "deallocate", "layoutstats", "clone"
     ),
     "proc3": (
         "null", "getattr", "setattr", "lookup", "access", "readlink",


### PR DESCRIPTION
nfs-utils/nfsstat.c is not the canonical source for rpc procedures.  The
version used missed a base entry, got the end of nfs4.1 wrong, and
didn't include nfs4.2.

Some names in the current version (e.g. create_session) may have changed
since they were put into this file (e.g. create_ses).  Existing names were
preserved.

See: http://git.linux-nfs.org/?p=steved/nfs-utils.git;a=blob_plain;f=utils/nfsstat/nfsstat.c;hb=HEAD