### PR TITLE
Fix issue #388 with eos collector & jsonrpclib

### DIFF
--- a/eos/collectors/eos.py
+++ b/eos/collectors/eos.py
@@ -33,6 +33,7 @@ class IntfCounterCollector(object):
       result = self.server_.runCmds(1, ["show interfaces counters",
                                         "show interfaces counters errors",
                                         "show interfaces counters bins"])
+      jsonrpclib.history.clear()
       (counters, error_counters, bin_counters) = result
 
       # Print general interface counters


### PR DESCRIPTION
Fixes issue #388 

```
diff --git a/eos/collectors/eos.py b/eos/collectors/eos.py
index 86da378..c3bd436 100755
--- a/eos/collectors/eos.py
+++ b/eos/collectors/eos.py
@@ -33,6 +33,7 @@ class IntfCounterCollector(object):
       result = self.server_.runCmds(1, ["show interfaces counters",
                                         "show interfaces counters errors",
                                         "show interfaces counters bins"])
+      jsonrpclib.history.clear()
       (counters, error_counters, bin_counters) = result

       # Print general interface counters 
```