### PR TITLE
updated HBase ports for modern versions of HBase (0.99+ @ 2014)

### DIFF
--- a/collectors/0/hbase_master.py
+++ b/collectors/0/hbase_master.py
@@ -31,11 +31,11 @@ class HBaseMaster(HadoopHttp):
     """
     Class to get metrics from Apache HBase's master
 
-    Require HBase 0.96.0+
+    Require HBase 0.99+
     """
 
     def __init__(self):
-        super(HBaseMaster, self).__init__('hbase', 'master', 'localhost', 60010)
+        super(HBaseMaster, self).__init__('hbase', 'master', 'localhost', 16010)
 
     def emit(self):
         current_time = int(time.time())

--- a/collectors/0/hbase_regionserver.py
+++ b/collectors/0/hbase_regionserver.py
@@ -30,7 +30,7 @@ REGION_METRIC_PATTERN = re.compile(r"[N|n]amespace_(.*)_table_(.*)_region_(.*)_m
 
 class HBaseRegionserver(HadoopHttp):
     def __init__(self):
-        super(HBaseRegionserver, self).__init__("hbase", "regionserver", "localhost", 60030)
+        super(HBaseRegionserver, self).__init__("hbase", "regionserver", "localhost", 16030)
 
     def emit_region_metric(self, context, current_time, full_metric_name, value):
 	match = REGION_METRIC_PATTERN.match(full_metric_name)


### PR DESCRIPTION
The HBase ports are several years out of date, 0.99+ from 2014/2015 onwards uses 16000 port range instead of 60000.

See https://issues.apache.org/jira/browse/HBASE-10123
