### PR TITLE
hbase regionserver Error splitting numRegions fix for #396

### DIFF
--- a/collectors/0/hbase_regionserver.py
+++ b/collectors/0/hbase_regionserver.py
@@ -61,7 +61,7 @@ class HBaseRegionserver(HadoopHttp):
             if any( c in EXCLUDED_CONTEXTS for c in context):
                 continue
 
-            if any(c == "regions" for c in context):
+            if any(c == "regions" for c in context) and '_region_' in metric_name:
                 if EMIT_REGION:
                     self.emit_region_metric(context, current_time, metric_name, value)
             else:


### PR DESCRIPTION
Here is a quick fix for the issue #396, this should start collecting that metric now instead of losing it and filling the tcollector logs with warnings.