### PR TITLE
Make start script linkable

### DIFF
--- a/tcollector
+++ b/tcollector
@@ -12,7 +12,7 @@ then
     TCOLLECTOR_PATH=/usr/local/share/tcollector
     export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 else
-    SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
+    SCRIPT_DIR="$(cd $(dirname $(readlink $0 || echo $0)) && pwd)"
     TCOLLECTOR_PATH=${TCOLLECTOR_PATH-"${SCRIPT_DIR}"}
 fi
 


### PR DESCRIPTION
Hi,

When start script is linked (from `/etc/init.d/` for instance), it will refuse to start as it will fail to compute  `TCOLLECTOR_PATH`.
This PR then solves this issue.

Thank you 👍 

Ben