### PR TITLE
Fix for multithreaded HAProxy (since HAProxy 1.8)

### DIFF
--- a/collectors/0/haproxy.py
+++ b/collectors/0/haproxy.py
@@ -93,7 +93,7 @@ METRIC_NAMES = {
 def haproxy_pid():
   """Finds out the pid of haproxy process"""
   try:
-     pid = subprocess.check_output(["pidof", "haproxy"])
+     pid = subprocess.check_output(["pidof", "-s", "haproxy"])
   except subprocess.CalledProcessError:
      return None
   return pid.rstrip()


### PR DESCRIPTION
For making the tcollector work with a multithreaded HAProxy, the pidof command should only get one PID. This is solved with the "-s" (Singleshot).