### PR TITLE
Fix order of checking if value is bool

### DIFF
--- a/collectors/0/jolokia.py
+++ b/collectors/0/jolokia.py
@@ -103,13 +103,15 @@ class JolokiaCollector():
             attribute, more_tags = self.parse_attribute(k.lower(), not_tags)
             metric_name = '.'.join([metric_prefix, attribute])
             my_tags = tags + more_tags
-            # If numerical
-            if utils.is_numeric(v):
-                print("%s %d %s %s" % (metric_name, timestamp, str(v),
-                                        ' '.join(my_tags)))
-            # If a bool, True=1, False=0
-            elif type(v) is bool:
+            # If a bool, True=1, False=0. 
+            # This check needs to run before utils.is_numeric(), as bool is a
+            # subclass of int and would match that check.
+            if type(v) is bool:
                 print("%s %d %s %s" % (metric_name, timestamp, str(int(v)),
+                                        ' '.join(my_tags)))
+            # If numerical
+            elif utils.is_numeric(v):
+                print("%s %d %s %s" % (metric_name, timestamp, str(v),
                                         ' '.join(my_tags)))
             # Or a dict of more attributes, call ourselves again
             elif type(v) is dict:

--- a/collectors/0/jolokia.py
+++ b/collectors/0/jolokia.py
@@ -158,7 +158,10 @@ class JolokiaCollector():
             tag_name, _, attrname = p.rpartition('=')
             tag_name = tag_name.split(':')[-1]
             # Swap out bad chars
-            attrname = attrname.replace('.', '_').replace('/', '').replace(' ', '_')
+            attrname = attrname.replace('.', '_')
+            attrname = attrname.replace('/', '')
+            attrname = attrname.replace(' ', '_')
+            attrname = attrname.replace('\'', '')
             pruned[tag_name] = attrname
 
         attr_list = []


### PR DESCRIPTION
bool is subclass of int and will match against a check in
`utils.is_numeric()`. This commit checks if `v` is bool before anything
else, so we catch it early.

```
>>> int.__subclasses__()
[<type 'bool'>]
>>> isinstance(True, (int))
True
>>> isinstance(True, (bool))
True
```

Previous behaviour was that jolokia tried to send `True` for booleans as
a value to opentsdb, which isn't allowed, and caused
`java.lang.NumberFormatException: For input string: "True"` in
application logs.