### PR TITLE
fix elasticsearch sending booleans to opentsdb

### DIFF
--- a/collectors/0/elasticsearch.py
+++ b/collectors/0/elasticsearch.py
@@ -106,6 +106,9 @@ def printmetric(metric, ts, value, tags):
                           for name, value in tags.items())
   else:
     tags = ""
+  # Convert any bool values to int, as opentsdb only accepts int or float.
+  if isinstance(value, bool):
+      value = int(value)
   print("%s %d %s %s"
          % (metric, ts, value, tags))
 


### PR DESCRIPTION
Added a generic bool-to-int convert in printmetric-function, so that any
booleans sent for printing will be converted to an integer.
Fixes an an issue where the metric `is_master` tried to send boolean
values, causing opentsdb to log `java.lang.NumberFormatException: For input string: "False"`

If this is too generic, one could fix the specific `is_master` value in
`_collect_server`-function, line 185 or 187 by explicitly changing only
that to `int()`, but figured the generic approach is future-proof for any
other metrics that might slip through as booleans.