### PR TITLE
Read command-line options' defaults from /etc/tcollector.json if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Improvements
 - An optional status monitoring API, serving JSON over HTTP
+- Command-line options can be configured using an optional `/etc/tcollector.json` configuration file.
 
 ## [1.3.1](https://github.com/OpenTSDB/tcollector/issues?utf8=%E2%9C%93&q=milestone%3A1.3.1+)
 ### Collectors Added

--- a/tcollector.py
+++ b/tcollector.py
@@ -914,6 +914,10 @@ def parse_cmdline(argv):
         sys.stderr.write("Unexpected error: %s\n" % e)
         raise
 
+    if os.path.exists("/etc/tcollector.json"):
+        with open("/etc/tcollector.json") as f:
+            defaults.update(json.load(f))
+
     # get arguments
     parser = OptionParser(description='Manages collectors which gather '
                                        'data and report back.')


### PR DESCRIPTION
Motivation:

* The `etc/config.py` file is typically installed as something you can't edit. For example, if you're using RPMs, upgrading to next release via RPM will overwrite local changes.
* Insofar as you can edit it, you're editing code.

By supporting a configuration file (`/etc/tcollector.json`) it's easier to have host-specific customization that isn't destroyed by upgrades.