### PR TITLE
fixed unicode problem

### DIFF
--- a/collectors/lib/hadoop_http.py
+++ b/collectors/lib/hadoop_http.py
@@ -23,6 +23,7 @@ try:
 except ImportError:
     from ordereddict import OrderedDict  # Can be easy_install'ed for <= 2.6
 from collectors.lib.utils import is_numeric
+from collectors.lib.utils import is_numeric_by_unicode
 
 try:
     from http.client import HTTPConnection
@@ -78,7 +79,10 @@ class HadoopHttp(object):
             for key, value in bean.items():
                 if key in EXCLUDED_KEYS:
                     continue
-                if not is_numeric(value):
+                if isinstance(value, unicode):
+                    if not is_numeric_by_unicode(value):
+                        continue
+                elif not is_numeric(value):
                     continue
                 kept.append((context, key, value))
         return kept

--- a/collectors/lib/hadoop_http.py
+++ b/collectors/lib/hadoop_http.py
@@ -79,10 +79,7 @@ class HadoopHttp(object):
             for key, value in bean.items():
                 if key in EXCLUDED_KEYS:
                     continue
-                if isinstance(value, unicode):
-                    if not is_numeric_by_unicode(value):
-                        continue
-                elif not is_numeric(value):
+                if not is_numeric(value):
                     continue
                 kept.append((context, key, value))
         return kept

--- a/collectors/lib/utils.py
+++ b/collectors/lib/utils.py
@@ -57,6 +57,21 @@ def is_sockfile(path):
 def err(msg):
     print(msg, file=sys.stderr)
 
+def is_numeric_by_unicode(s):
+    try:
+      float(str(s))
+      return True
+    except ValueError:
+      pass
+
+    try:
+      import unicodedata
+      unicodedata.numeric(s)
+      return True
+    except (TypeError, ValueError):
+      pass
+
+    return False
 
 if PY3:
     def is_numeric(value):

--- a/collectors/lib/utils.py
+++ b/collectors/lib/utils.py
@@ -58,24 +58,24 @@ def err(msg):
     print(msg, file=sys.stderr)
 
 def is_numeric_by_unicode(s):
-    try:
-      float(str(s))
-      return True
-    except ValueError:
-      pass
 
-    try:
-      import unicodedata
-      unicodedata.numeric(s)
-      return True
-    except (TypeError, ValueError):
-      pass
-
-    return False
 
 if PY3:
     def is_numeric(value):
         return isinstance(value, (int, float))
 else:
     def is_numeric(value):
-        return isinstance(value, (int, long, float)) # pylint: disable=undefined-variable
+        try:
+            float(str(value))
+            return True
+        except ValueError:
+            pass
+
+        try:
+            import unicodedata
+            unicodedata.numeric(s)
+            return True
+        except (TypeError, ValueError):
+            pass
+
+        return False


### PR DESCRIPTION
When hbase metric is collected through collector in the poll() method of hadoop_http.py, when value is of type Unicode, it is filtered by is_numeric, which determines whether value is a (int, long, float) and subclass.Hence the need for compatibility with Unicode types.