### PR TITLE
Fix dictionary element deletion error in python3

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -240,7 +240,7 @@ class Collector(object):
           cut_off: A UNIX timestamp.  Any value that's older than this will be
             removed from the cache.
         """
-        for key in self.values.keys():
+        for key in list(self.values):
             time = self.values[key][3]
             if time < cut_off:
                 del self.values[key]


### PR DESCRIPTION
In python3 we get this exception 


Traceback (most recent call last):
  File "/opt/tcollector/tcollector.py", line 375, in run
    col.evict_old_keys(now)
  File "/opt/tcollector/tcollector.py", line 276, in evict_old_keys
    for key in self.values.keys():
RuntimeError: dictionary changed size during iteration
2021-01-23 16:54:56,333 tcollector[20919] INFO: Reading from processstats.py


This issue is discussed here.

https://stackoverflow.com/questions/11941817/how-to-avoid-runtimeerror-dictionary-changed-size-during-iteration-error


Please review the changes.