### PR TITLE
Riak collector configuration parameters.

### DIFF
--- a/collectors/0/riak.py
+++ b/collectors/0/riak.py
@@ -45,12 +45,15 @@ import os
 import sys
 import time
 
+from collectors.etc import riak_conf
 from collectors.lib import utils
 
 try:
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
+
+CONFIG = riak_conf.get_default_config()
 
 MAP = {
     'vnode_gets_total': ('vnode.requests', 'type=get'),
@@ -96,7 +99,7 @@ def main():
     while True:
         ts = int(time.time())
 
-        req = urlopen("http://localhost:8098/stats")
+        req = urlopen(CONFIG['stats_endpoint'])
         if req is not None:
             obj = json.loads(req.read())
             for key in obj:

--- a/collectors/etc/riak_conf.py
+++ b/collectors/etc/riak_conf.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+def onload(options, tags):
+    pass
+
+def get_default_config():
+    config = {
+        'stats_endpoint': 'http://localhost:8098/stats'
+    }
+
+    return config


### PR DESCRIPTION
Implemented a separate configuration location for the Riak collector to avoid hard coding entries that are best located in a configuration file. In this case, the Riak stats HTTP endpoint.