### PR TITLE
Translate device mapper numbers to names.

### DIFF
--- a/collectors/0/iostat.py
+++ b/collectors/0/iostat.py
@@ -69,6 +69,7 @@ from __future__ import print_function
 import copy
 import os
 import re
+import stat
 import sys
 import time
 
@@ -101,6 +102,13 @@ FIELDS_PART = (
 
 prev_times = (0, 0)
 
+mapper_path     = '/dev/mapper'
+dm2lv           = {}
+mapper_path_dir = os.listdir(mapper_path)
+for dir in mapper_path_dir:
+    if dir != 'control':
+        s = os.stat(mapper_path + '/' + dir)
+        dm2lv[(os.major(s.st_rdev),os.minor(s.st_rdev))] = dir
 
 def read_uptime():
   global prev_times
@@ -197,6 +205,8 @@ def main():
         metric = "iostat.part."
 
       device = values[2]
+      if (int(values[0]),int(values[1])) in dm2lv:
+        device = dm2lv[(int(values[0]),int(values[1]))]
       if len(values) == 14:
         # full stats line
         for i in range(11):


### PR DESCRIPTION
Hello and thank you for tcollector,
For iostat.py, for device mapper devices, instead of a number: dev=dm-6
it would be the name:
dev=a-free-man

Any additions or changes to entries under /dev/mapper would require the collector to be restarted in order to pick up the mapping from device mapper number to name.

Originally from https://github.com/OpenTSDB/tcollector/pull/148 on Mar 28, 2014.  This is not something I work on these days, and I have not tested this, just reapplied the patch as per https://github.com/OpenTSDB/tcollector/pull/148#issuecomment-2079992593